### PR TITLE
Fix endOfLineForURLAndContinueScanning parser callback to not treat one character lines as blank

### DIFF
--- a/mambaSharedFramework/HLS Rapid Parser/RapidParserStateHandlers.c
+++ b/mambaSharedFramework/HLS Rapid Parser/RapidParserStateHandlers.c
@@ -58,7 +58,7 @@ uint8_t endOfLineForURLAndContinueScanning(const void *parentparser, const unsig
     // index is currently a newline. we do not want to include it
     lineState->start = index + 1;
     
-    if ( lineState->end <= lineState->start ) {
+    if ( lineState->end < lineState->start ) {
         // this is either a blank line or a \n\r pair. We're not going to parse this, just keep moving
         lineState->end = index - 1;
         return Scanning;

--- a/mambaTests/HLSParserTest.swift
+++ b/mambaTests/HLSParserTest.swift
@@ -408,6 +408,20 @@ class HLSParserTest: XCTestCase {
         runParseExpectingFailure(withManfiestString: playlistString)
     }
     
+    func testParserWithShortTag() {
+        let playlistString = """
+#EXT3MU
+#EXTINF:5000
+a
+"""
+        let playlist = parsePlaylist(inString: playlistString)
+        
+        XCTAssert(playlist.tags.count == 3, "Unexpected number of tags")
+        XCTAssert(playlist.tags[1].tagDescriptor == PantosTag.EXTINF, "Second tag is not an EXTINF")
+        XCTAssert(playlist.tags[2].tagDescriptor == PantosTag.Location, "Third tag is not a Location")
+        XCTAssert(playlist.tags[2].tagData.isEqual(to: "a"), "Location tag does not have expected value")
+    }
+    
     func runParseExpectingFailure(withManfiestString playlistString: String) {
         let url: URL = fakePlaylistURL()
         let parser = HLSParser()

--- a/mambaTests/HLSPlaylistTimelineAndSequencingTests.swift
+++ b/mambaTests/HLSPlaylistTimelineAndSequencingTests.swift
@@ -397,31 +397,31 @@ class HLSPlaylistTimelineAndSequencingTests: XCTestCase {
  */
 
 
-fileprivate let sampleVariantPlaylist_mediaSequenceMissing = sampleVariantPlaylist_begin + sampleVariantPlaylist_end
-fileprivate let sampleVariantPlaylist_mediaSequence4 = sampleVariantPlaylist_begin + "#EXT-X-MEDIA-SEQUENCE:4\n" + sampleVariantPlaylist_end
+fileprivate let sampleVariantPlaylist_mediaSequenceMissing = sampleVariantPlaylist_begin + "\n" + sampleVariantPlaylist_end
+fileprivate let sampleVariantPlaylist_mediaSequence4 = sampleVariantPlaylist_begin + "\n#EXT-X-MEDIA-SEQUENCE:4\n" + sampleVariantPlaylist_end
 
 fileprivate let sampleVariantPlaylist_begin = """
-#EXTM3U\n
-#EXT-X-VERSION:4\n
-#EXT-X-PLAYLIST-TYPE:VOD\n
-#EXT-X-TARGETDURATION:2\n
+#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:2
 """
 
 fileprivate let sampleVariantPlaylist_end = """
-#EXTINF:2.002,\n
-http://not.a.server.nowhere/segment1.ts\n
-#EXTINF:1.0,\n
-#EXT-X-DISCONTINUITY\n
-#EXT-X-KEY:METHOD=AES-128,URI=\"https://not.a.server.nowhere/key.php?r=52\",IV=0x9c7db8778570d05c3177c349fd9236aa/\n
-#EXT-X-BYTERANGE:82112@752321\n
-http://not.a.server.nowhere/segment2.ts\n
-#EXTINF:2.002,\n
-http://not.a.server.nowhere/segment3.ts\n
-#EXTINF:2.002,\n
-http://not.a.server.nowhere/segment4.ts\n
-#EXTINF:2.002,\n
-http://not.a.server.nowhere/segment5.ts\n
-#EXTINF:2.002,\n
-http://not.a.server.nowhere/segment6.ts\n
-#EXT-X-ENDLIST\n"
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment1.ts
+#EXTINF:1.0,
+#EXT-X-DISCONTINUITY
+#EXT-X-KEY:METHOD=AES-128,URI=\"https://not.a.server.nowhere/key.php?r=52\",IV=0x9c7db8778570d05c3177c349fd9236aa/
+#EXT-X-BYTERANGE:82112@752321
+http://not.a.server.nowhere/segment2.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment3.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment4.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment5.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment6.ts
+#EXT-X-ENDLIST
 """


### PR DESCRIPTION
### Description

This PR fixes issue #1

### Change Notes

* The `endOfLineForURLAndContinueScanning` function was using a `<=` rather than a `<` to try to detect blank lines. This meant that one character lines were treated as blank and skipped. Changed to `<`.
* New unit test `testParserWithShortTag` to test for this issue.
* This changes uncovered problems in the whole `HLSPlaylistTimelineAndSequencingTests` suite of tests related to the test playlist strings. They were poorly converted to the new swift ``` format, and did not have correct newline spacing. This was also fixed in this PR.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
