### PR TITLE
Alter Mamba.version to not require a bundle identifier. Bump version to 1.0.1

### DIFF
--- a/mamba.podspec
+++ b/mamba.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name              = "mamba"
-s.version           = "1.0.0"
+s.version           = "1.0.1"
 s.license           = { :type => 'Apache License, Version 2.0',
                         :text => <<-LICENSE
                             Copyright 2017 Comcast Cable Communications Management, LLC

--- a/mamba/Info.plist
+++ b/mamba/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/mambaSharedFramework/Mamba.swift
+++ b/mambaSharedFramework/Mamba.swift
@@ -25,10 +25,7 @@ public enum Mamba {
     /// returns the version of the mamba framework
     public static var version: String {
         
-        guard let bundle = Bundle(identifier: bundleName) else {
-            assertionFailure("Unable to find framework bundle")
-            return "Error: Unable to find framework bundle"
-        }
+        let bundle = Bundle(for: HLSParser.self)
         
         guard let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
             assertionFailure("Unable to find version string in framework bundle")
@@ -38,5 +35,3 @@ public enum Mamba {
         return version
     }
 }
-
-private let bundleName = "com.comcast.mamba"


### PR DESCRIPTION

### Description

This PR fixes issue #6

### Change Notes

* `Mamba.version` now no longer requires a specific bundle identifer. 
* We're going to follow this bug fix up with an immediate release, so also bumped the version number up to 1.0.1

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature. (Changes covered by existing unit tests)
