### PR TITLE
Setting the EXT-X-TARGETDURATION tag validator to be less strict to be in line with the HLS Pantos Specification

### DIFF
--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXT_X_TARGETDURATIONLengthValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXT_X_TARGETDURATIONLengthValidator.swift
@@ -35,7 +35,7 @@ class EXT_X_TARGETDURATIONLengthValidator: HLSPlaylistOneToManyValidator {
                 else { return nil }
             
             for tag in many {
-                if tag.duration.seconds.rounded(.down) > max {
+                if tag.duration.seconds.rounded(.toNearestOrAwayFromZero) > max {
                     return [HLSValidationIssue(description: IssueDescription.EXT_X_TARGETDURATIONLengthValidator, severity: IssueSeverity.error)]
                 }
             }

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXT_X_TARGETDURATIONLengthValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXT_X_TARGETDURATIONLengthValidator.swift
@@ -31,11 +31,11 @@ class EXT_X_TARGETDURATIONLengthValidator: HLSPlaylistOneToManyValidator {
             
             guard let one = one,
                 let many = many,
-                let max: CMTime = one.value(forValueIdentifier: PantosValue.targetDurationSeconds)
+                let max: Double = one.value(forValueIdentifier: PantosValue.targetDurationSeconds)
                 else { return nil }
             
             for tag in many {
-                if tag.duration > max {
+                if tag.duration.seconds.rounded(.down) > max {
                     return [HLSValidationIssue(description: IssueDescription.EXT_X_TARGETDURATIONLengthValidator, severity: IssueSeverity.error)]
                 }
             }

--- a/mambaTests/HLSValidatorTests.swift
+++ b/mambaTests/HLSValidatorTests.swift
@@ -481,7 +481,7 @@ class HLSValidatorTests: XCTestCase {
 #EXTM3U
 #EXT-X-PLAYLIST-TYPE:VOD
 #EXT-X-TARGETDURATION:6
-#EXTINF:6.999
+#EXTINF:6.49
 frag1.ts
 """
         let u = EXT_X_TARGETDURATIONLengthValidator.self
@@ -494,7 +494,7 @@ frag1.ts
 #EXTM3U
 #EXT-X-PLAYLIST-TYPE:VOD
 #EXT-X-TARGETDURATION:6
-#EXTINF:7.00
+#EXTINF:6.7
 frag1.ts
 """
         let u = EXT_X_TARGETDURATIONLengthValidator.self

--- a/mambaTests/HLSValidatorTests.swift
+++ b/mambaTests/HLSValidatorTests.swift
@@ -475,6 +475,32 @@ class HLSValidatorTests: XCTestCase {
         validate(validator: u, playlist: hlsLoadString, expected: 1)
     }
 
+    func testEXT_X_TARGETDURATIONLengthValidationEXTINFDurationAtLimit() {
+        
+        let hlsLoadString = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:6
+#EXTINF:6.999
+frag1.ts
+"""
+        let u = EXT_X_TARGETDURATIONLengthValidator.self
+        validate(validator: u, playlist: hlsLoadString, expected: 0)
+    }
+
+    func testEXT_X_TARGETDURATIONLengthValidationEXTINFDurationBeyondLimit() {
+        
+        let hlsLoadString = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:6
+#EXTINF:7.00
+frag1.ts
+"""
+        let u = EXT_X_TARGETDURATIONLengthValidator.self
+        validate(validator: u, playlist: hlsLoadString, expected: 1)
+    }
+
     func testMatchingPROGRAM_IDValidatorOK() {
         
         let hlsLoadString = AudioVideoGroup_txt.joined()


### PR DESCRIPTION

### Description

This PR fixes a bug where the EXT-X-TARGETDURATION tag validator is too strict. If the EXT-X-TARGETDURATION tag is set to "6", and the fragments are "6.006" this is actually correct from the HLS spec (section 4.3.3.1, https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#page-21).

The previous code would have failed this.

### Change Notes

* Changed `EXT_X_TARGETDURATIONLengthValidator` to implement new rules.
* Added unit tests for new rules.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
