### PR TITLE
Fix EXT-X-DISCONTINUITY-SEQUENCE PantosTag type from `Date` to `Int`

### DIFF
--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
@@ -369,8 +369,8 @@ extension PantosTag: HLSTagDescriptor, Equatable {
             return GenericSingleTagValidator<Date>(tag: pantostag,
                                                    singleValueIdentifier:PantosValue.programDateTime)
         case .EXT_X_DISCONTINUITY_SEQUENCE:
-            return GenericSingleTagValidator<Date>(tag: pantostag,
-                                                   singleValueIdentifier:PantosValue.discontinuitySequence)
+            return GenericSingleTagValidator<Int>(tag: pantostag,
+                                                  singleValueIdentifier:PantosValue.discontinuitySequence)
             
         case .EXT_X_STREAM_INF:
             return GenericDictionaryTagValidator(tag: pantostag, dictionaryValueIdentifiers: [

--- a/mambaTests/PantosTagTests.swift
+++ b/mambaTests/PantosTagTests.swift
@@ -120,4 +120,15 @@ class PantosTagTests: XCTestCase {
         // (3) Add the new tag to the `PantosTagTests.testStringRefLookup.runStringRefLookupTest` above as well.
         // If you don't do these steps, this tag will not be recognized by the PantosTag, and will be treated like an unknown tag.
     }
+    
+    func testDISCONTINUITYSEQUENCEValidator() {
+        guard let validator = PantosTag.validator(forTag: PantosTag.EXT_X_DISCONTINUITY_SEQUENCE) else {
+            XCTFail("Could not find validator for PantosTag.EXT_X_DISCONTINUITY_SEQUENCE")
+            return
+        }
+        let issues = validator.validate(tag: HLSTag(tagDescriptor: PantosTag.EXT_X_DISCONTINUITY_SEQUENCE,
+                                                    stringTagData: "0",
+                                                    parsedValues: [PantosValue.discontinuitySequence.toString(): HLSValueData(value: "0")]))
+        XCTAssertNil(issues, "Expecting no issues from validator")
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes a typing bug in `PantosTag`. `EXT-X-DISCONTINUITY-SEQUENCE ` was set to being a `Date` type, which it is actually an `Int` type.

### Change Notes

* Fixes `PantosTag` to use the correct type.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
