### PR TITLE
 Fix a bug where EXT-X-DISCONTINUITY-SEQUENCE tags were labelled as .mediaSegment instead of .wholePlaylist

### DIFF
--- a/mamba/Info.plist
+++ b/mamba/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
@@ -105,8 +105,6 @@ extension PantosTag: HLSTagDescriptor, Equatable {
             fallthrough
         case .EXT_X_DISCONTINUITY:
             fallthrough
-        case .EXT_X_DISCONTINUITY_SEQUENCE:
-            fallthrough
         case .EXTINF:
             return .mediaSegment
             
@@ -131,6 +129,8 @@ extension PantosTag: HLSTagDescriptor, Equatable {
         case .EXT_X_INDEPENDENT_SEGMENTS:
             fallthrough
         case .EXT_X_START:
+            fallthrough
+        case .EXT_X_DISCONTINUITY_SEQUENCE:
             fallthrough
         case .EXT_X_TARGETDURATION:
             return .wholePlaylist


### PR DESCRIPTION

### Description

This PR fixes a bug where `EXT-X-DISCONTINUITY-SEQUENCE` tags were labelled as `.mediaSegment` instead of `.wholePlaylist`

### Change Notes

* Changed `PantosTag.scope()` to return correct value.
* Bumped version number, as there will be a release to fix this as soon as merged.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
