### PR TITLE
added swift version preprocessor for using compactMap

### DIFF
--- a/mambaSharedFramework/HLS Models/Playlist Structure/HLSPlaylistStructureInterface.swift
+++ b/mambaSharedFramework/HLS Models/Playlist Structure/HLSPlaylistStructureInterface.swift
@@ -104,7 +104,12 @@ extension HLSPlaylistStructureInterface {
         var results = [MediaSegmentTagGroup]()
         
         for group in mediaSegmentGroups {
+            #if swift(>=4.1)
             let tagNames: Set<HLSStringRef> = Set(tags[group.range].compactMap { $0.tagName })
+            #else
+            let tagNames: Set<HLSStringRef> = Set(tags[group.range].flatMap { $0.tagName })
+            #endif
+
             if queryTagNameSet.intersection(tagNames).count > 0 {
                 results.append(group)
             }


### PR DESCRIPTION
### Description

Adds Swift 4.0 backwards compatibility

### Change Notes

Added pre-processor to use deprecated flatMap operator

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [NA] I have written useful documentation for all public code.
- [NA] I have written unit tests for this new feature.

