### PR TITLE
Removed canQueryTimeline check from mediaSequence ↔ tagIndex methods

### DIFF
--- a/mamba.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/mamba.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/mambaSharedFramework/HLS Models/HLSPlaylistInterface.swift
+++ b/mambaSharedFramework/HLS Models/HLSPlaylistInterface.swift
@@ -89,8 +89,6 @@ extension HLSPlaylistInterface {
     }
     
     public func mediaSequence(forTagIndex tagIndex: Int) -> MediaSequence? {
-        guard canQueryTimeline() else { return nil }
-        
         guard let segmentGroup = segmentGroup(forTagIndex: tagIndex) else { return nil }
         
         return segmentGroup.mediaSequence
@@ -113,8 +111,6 @@ extension HLSPlaylistInterface {
     }
     
     public func tagIndexes(forMediaSequence mediaSequence: MediaSequence) -> HLSTagIndexRange? {
-        guard canQueryTimeline() else { return nil }
-        
         guard let segmentGroup = segmentGroup(forMediaSequence: mediaSequence) else { return nil }
         
         return segmentGroup.startIndex...segmentGroup.endIndex

--- a/mambaTests/HLSPlaylistInterfaceTests.swift
+++ b/mambaTests/HLSPlaylistInterfaceTests.swift
@@ -105,6 +105,79 @@ class HLSPlaylistInterfaceTests: XCTestCase {
         XCTAssertNil(playlistMaster.timeRange(forTagIndex: 0))
         XCTAssertNil(playlistMaster.timeRange(forMediaSequence: 0))
         XCTAssertNil(playlistMaster.tagIndexes(forTime: kCMTimeZero))
-        XCTAssertNil(playlistMaster.tagIndexes(forMediaSequence: 0))
+        XCTAssertNotNil(playlistMaster.tagIndexes(forMediaSequence: 0))
+    }
+    
+    func testTagIndexesForVodPlaylist() {
+        let playlist = """
+                        #EXTM3U
+                        #EXT-X-PLAYLIST-TYPE:VOD
+                        #EXT-X-MEDIA-SEQUENCE:0
+                        #EXT-X-TARGETDURATION:3
+                        #EXT-X-VERSION:3
+                        #EXTINF:2.96130,
+                        fileSequence0.ts
+                        #EXTINF:2.96130,
+                        fileSequence1.ts
+                        #EXTINF:2.96129,
+                        fileSequence2.ts
+                        #EXTINF:2.96129,
+                        fileSequence3.ts
+                        #EXTINF:2.96130,
+                        fileSequence4.ts
+                        #EXTINF:2.96130,
+                        fileSequence5.ts
+                        #EXTINF:2.96129,
+                        fileSequence6.ts
+                        #EXTINF:2.96129,
+                        fileSequence7.ts
+                        #EXTINF:2.96130,
+                        fileSequence8.ts
+                        #EXTINF:2.96130,
+                        fileSequence9.ts
+                        #EXTINF:2.96129,
+                        fileSequence10.ts
+                        """
+        
+        let parsed = parsePlaylist(inString: playlist)
+        
+        let tagIndexes = parsed.tagIndexes(forMediaSequence: 0)
+        XCTAssertNotNil(tagIndexes, "Tag indexes should not be nil")
+    }
+    
+    func testTagIndexesForImpliedLivePlaylist() {
+        let playlist = """
+                        #EXTM3U
+                        #EXT-X-MEDIA-SEQUENCE:0
+                        #EXT-X-TARGETDURATION:3
+                        #EXT-X-VERSION:3
+                        #EXTINF:2.96130,
+                        fileSequence0.ts
+                        #EXTINF:2.96130,
+                        fileSequence1.ts
+                        #EXTINF:2.96129,
+                        fileSequence2.ts
+                        #EXTINF:2.96129,
+                        fileSequence3.ts
+                        #EXTINF:2.96130,
+                        fileSequence4.ts
+                        #EXTINF:2.96130,
+                        fileSequence5.ts
+                        #EXTINF:2.96129,
+                        fileSequence6.ts
+                        #EXTINF:2.96129,
+                        fileSequence7.ts
+                        #EXTINF:2.96130,
+                        fileSequence8.ts
+                        #EXTINF:2.96130,
+                        fileSequence9.ts
+                        #EXTINF:2.96129,
+                        fileSequence10.ts
+                        """
+        
+        let parsed = parsePlaylist(inString: playlist)
+        
+        let tagIndexes = parsed.tagIndexes(forMediaSequence: 0)
+        XCTAssertNotNil(tagIndexes, "Tag indexes should not be nil")
     }
 }


### PR DESCRIPTION
### Description

This PR removes two unnecessary checks of `canQueryTimeline` in  mediaSequence ↔ tagIndex methods, and adds two test to clarify the behavior of `tagIndexes(forMediaSequence:)`

### Change Notes

* Removed call to `canQueryTimeline` in  mediaSequence ↔ tagIndex methods.
* Added new test, `testTagIndexesForVodPlaylist`.
* Added new test, `testTagIndexesForImpliedLivePlaylist`.
* Added `IDEDidComputeMac32BitWarning` change to `IDEWorkspaceChecks.plist`.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no new compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

