### PR TITLE
Change Playlist debug description to be the hls output

### DIFF
--- a/mambaSharedFramework/HLS Models/HLSPlaylistCore.swift
+++ b/mambaSharedFramework/HLS Models/HLSPlaylistCore.swift
@@ -162,7 +162,11 @@ public struct HLSPlaylistCore<T>: HLSPlaylistInterface, CustomDebugStringConvert
     }
     
     public var playlistCoreDebugDescription: String {
-        return "registeredTags:\(registeredTags) \nstructure:\(structure)\n"
+        guard let stream = try? self.write(),
+            let debugDescription = String(data: stream, encoding: .utf8) else {
+            return "Stream write failure. Raw Data: registeredTags:\(registeredTags) \nstructure:\(structure)\n"
+        }
+        return String(debugDescription)
     }
     
     /**


### PR DESCRIPTION
### Description

This PR implements feature #13 .

### Change Notes

* Changes Playlist debug description to be the hls output.
* Falls back to original output when write fails

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

