### PR TITLE
protect C parser from an empty data set leading to crash during parse

### DIFF
--- a/mambaSharedFramework/HLS Rapid Parser/RapidParser.c
+++ b/mambaSharedFramework/HLS Rapid Parser/RapidParser.c
@@ -35,7 +35,7 @@ void parseHLS(const void *parentparser, const unsigned char *bytes, const uint64
     
     rapid_parser_debug_print("Begining parse of hls data with length %llu\n", length);
     
-    do {
+    while (index > 0 && state != ErrorEarlyExit) {
         
         index -= 1;
         
@@ -43,7 +43,7 @@ void parseHLS(const void *parentparser, const unsigned char *bytes, const uint64
         
         rapid_parser_debug_print("State %i after processing character %c at index %llu\n", (int)state, bytes[index], index);
         
-    } while (index > 0 && state != ErrorEarlyExit);
+    }
     
     if (index == 0 && state != ErrorEarlyExit) {
         // handle the final line, force a line completion

--- a/mambaSharedFramework/HLSParser.swift
+++ b/mambaSharedFramework/HLSParser.swift
@@ -282,6 +282,11 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
     }
     
     func startParse() {
+        // special case if data is empty return an empty array of tags
+        if self.data.isEmpty {
+            self.parseComplete()
+            return
+        }
         fastParser.parseHLSData(self.data, callback: self)
     }
 

--- a/mambaSharedFramework/HLSParser.swift
+++ b/mambaSharedFramework/HLSParser.swift
@@ -282,11 +282,6 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
     }
     
     func startParse() {
-        // special case if data is empty return an empty array of tags
-        if self.data.isEmpty {
-            self.parseComplete()
-            return
-        }
         fastParser.parseHLSData(self.data, callback: self)
     }
 

--- a/mambaTests/HLSParserTest.swift
+++ b/mambaTests/HLSParserTest.swift
@@ -415,6 +415,74 @@ class HLSParserTest: XCTestCase {
         XCTAssert(playlist?.tags.count == 0, "playlist should be empty")
     }
     
+    func testNearlyEmptyDataParse() {
+        
+        let data = " ".data(using: .utf8)!
+        
+        let parser = HLSParser()
+        
+        let expectation = self.expectation(description: "parse completion")
+        
+        var playlist: HLSPlaylist? = nil
+        
+        let url = URL(string: "http://test.nowhere")!
+        
+        parser.parse(playlistData: data,
+                     url: url,
+                     success: { (m) in
+                        playlist = m
+                        expectation.fulfill()
+        },
+                     failure: { (error) in
+                        XCTFail("testParserWithURL failure")
+                        expectation.fulfill()
+        })
+        
+        waitForExpectations(timeout: 2.0, handler: {
+            error in
+            if (error != nil) {
+                print("Parse timeout in testParserWithURL: \(error!)")
+                XCTFail()
+            }
+        })
+        
+        XCTAssertNotNil(playlist, "playlist should exist")
+    }
+    
+    func testNewlineDataParse() {
+        
+        let data = "\n".data(using: .utf8)!
+        
+        let parser = HLSParser()
+        
+        let expectation = self.expectation(description: "parse completion")
+        
+        var playlist: HLSPlaylist? = nil
+        
+        let url = URL(string: "http://test.nowhere")!
+        
+        parser.parse(playlistData: data,
+                     url: url,
+                     success: { (m) in
+                        playlist = m
+                        expectation.fulfill()
+        },
+                     failure: { (error) in
+                        XCTFail("testParserWithURL failure")
+                        expectation.fulfill()
+        })
+        
+        waitForExpectations(timeout: 2.0, handler: {
+            error in
+            if (error != nil) {
+                print("Parse timeout in testParserWithURL: \(error!)")
+                XCTFail()
+            }
+        })
+        
+        XCTAssertNotNil(playlist, "playlist should exist")
+    }
+    
     func testParseInvalidEXTINF_no_colon() {
         
         let playlistString = """

--- a/mambaTests/HLSParserTest.swift
+++ b/mambaTests/HLSParserTest.swift
@@ -381,6 +381,40 @@ class HLSParserTest: XCTestCase {
         XCTAssert(playlist2?.tags.count == 5, "Unexpected number of tags")
     }
     
+    func testEmptyDataParse() {
+        
+        let data = Data()
+        
+        let parser = HLSParser()
+        
+        let expectation = self.expectation(description: "parse completion")
+        
+        var playlist: HLSPlaylist? = nil
+        
+        let url = URL(string: "http://test.nowhere")!
+        
+        parser.parse(playlistData: data,
+                     url: url,
+                     success: { (m) in
+                        playlist = m
+                        expectation.fulfill()
+        },
+                     failure: { (error) in
+                        XCTFail("testParserWithURL failure")
+                        expectation.fulfill()
+        })
+        
+        waitForExpectations(timeout: 2.0, handler: {
+            error in
+            if (error != nil) {
+                print("Parse timeout in testParserWithURL: \(error!)")
+                XCTFail()
+            }
+        })
+        
+        XCTAssert(playlist?.tags.count == 0, "playlist should be empty")
+    }
+    
     func testParseInvalidEXTINF_no_colon() {
         
         let playlistString = """


### PR DESCRIPTION
### Description

This PR implements feature #18.

### Change Notes

* Added `isEmpty` check to data object in `HLSParser` before assumed non-null when passed to C parser.
* Added unit test

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

