### PR TITLE
Add a playground to mamba 

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ extension MyCustomValueIdentifiers: HLSTagValueIdentifier {
 
 You can now look through `HLSTag` objects for your custom tag values just as if it were a valuetype defined in the HLS specification.
 
+#### See the playground included in the workspace for more example code.
+
 ### _Important Note About Memory Safety_
 
 In order to achieve our performance goals, the internal C parser for HLS had to minimize the amount of heap memory allocated.

--- a/mamba.xcworkspace/contents.xcworkspacedata
+++ b/mamba.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:/Users/jpierc213/Documents/Development/mamba/mambaPlayground.playground">
+   </FileRef>
+   <FileRef
+      location = "group:mamba.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/mambaPlayground.playground/Contents.swift
+++ b/mambaPlayground.playground/Contents.swift
@@ -1,0 +1,10 @@
+import UIKit
+import mamba
+
+let hlsSamplePlaylistMaster = "#EXTM3U\n#EXT-X-VERSION:6\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2855600,CODECS=\"avc1.4d001f,mp4a.40.2\",RESOLUTION=960x540\nlive/medium.m3u8\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=5605600,CODECS=\"avc1.640028,mp4a.40.2\",RESOLUTION=1280x720\nlive/high.m3u8"
+
+let parser = HLSParser()
+let master:Data = hlsSamplePlaylistMaster.data(using: .utf8)!
+let url = URL(string:"http://nowhere")!
+let playlist:HLSPlaylist = try! parser.parse(playlistData: master, url: url)
+print(playlist)

--- a/mambaPlayground.playground/Pages/Editing and validating a playlist.xcplaygroundpage/Contents.swift
+++ b/mambaPlayground.playground/Pages/Editing and validating a playlist.xcplaygroundpage/Contents.swift
@@ -1,0 +1,67 @@
+//: [Previous](@previous)
+import Foundation
+import mamba
+/*: HLSPlaylists are highly editable, just insert a new `HLSTag` into the tags array. Some examples of what you can do:
+ 
+ Remove tag(s) to a playlist
+ */
+var playlist: HLSPlaylist = ParsedHLSPlaylists.variant
+guard let segment = playlist.mediaSegmentGroups.last else {
+    fatalError()
+}
+print(playlist)
+playlist.delete(atRange: segment.range)
+print(playlist)
+
+//: Add tag(s) to a playlist
+let tagInf: HLSTag = HLSTag(tagDescriptor: PantosTag.EXTINF, stringTagData: "5220,2")
+let tagLoc: HLSTag = HLSTag(tagDescriptor: PantosTag.Location, tagData:HLSStringRef(string: "http://media.example.com/entire_1.ts"))
+playlist.insert(tags: [tagInf,tagLoc], atIndex: playlist.mediaSegmentGroups.last!.endIndex + 1)
+print(playlist)
+
+//: Transform all tags in a playlist matching a criteria
+do {
+    try playlist.transform({ tag in
+        if tag.tagDescriptor == PantosTag.Location {
+            return HLSTag(tagDescriptor: PantosTag.Location, tagData: toHttps(tag.tagData))
+        }
+        return tag
+    })
+}
+catch {
+    fatalError()
+}
+print(playlist)
+
+playlist = ParsedHLSPlaylists.variant
+//: You can also validate the playlist
+if let issues = HLSCompletePlaylistValidator.validate(hlsPlaylist: playlist) {
+    print(issues)// Here we see our sample HLS is invalid due to our segment durations (5220) greatly exceeding or target duration of 10
+} else {
+    print("valid HLS")
+}
+do {
+    try playlist.transform({ tag in
+        var tag = tag
+        if tag.tagDescriptor == PantosTag.EXT_X_TARGETDURATION {
+            tag.set(value: "5220", forKey: PantosValue.targetDurationSeconds.rawValue)
+        }
+        return tag
+    })
+}
+catch {
+    fatalError()
+}
+print("\n")
+if let issues = HLSCompletePlaylistValidator.validate(hlsPlaylist: playlist) {
+    print(issues)
+} else {
+    print("valid HLS")// After the transform, we're now valid
+}
+
+//: [Next](@next)
+
+func toHttps(_ stringRef:HLSStringRef) -> HLSStringRef {
+    let string = stringRef.stringValue().replacingOccurrences(of: "http", with: "https")
+    return HLSStringRef(string: string)
+}

--- a/mambaPlayground.playground/Pages/Parsing a playlist.xcplaygroundpage/Contents.swift
+++ b/mambaPlayground.playground/Pages/Parsing a playlist.xcplaygroundpage/Contents.swift
@@ -1,0 +1,39 @@
+import Foundation
+import mamba
+
+/*: # Parsing a playlist
+ In General to parse a playlist you'll need: a `HLSParser`, the source of HLS `Data`, and the `URL` of the playlist resource. */
+let parser = HLSParser()
+let playlistData: Data = SamplePlaylist.master
+let playlistUrl: URL = URL(string: "http://nowhere")!
+
+//: Playlists can be parsed asynchronously
+
+parser.parse(playlistData: playlistData,
+             url: playlistUrl,
+             success: { (playlist) in
+                print("asych:\n\(playlist)")
+             },
+             failure: { (error) in
+                print(error)
+                })
+
+//: Or syncronously
+guard let playlist: HLSPlaylist = try? parser.parse(playlistData:playlistData, url:playlistUrl) else {
+    print("playlist parse failed")
+    fatalError()
+}
+print("sych:\n\(playlist)")
+
+//: If you have custom HLSTags not defined in `PantosTags` that you'll be parsing, pass them to the `HLSParser` on initialization
+let customParser = HLSParser(tagTypes: [CustomTag.self])
+customParser.parse(playlistData:SamplePlaylist.masterWithCustomTag,
+                   url:playlistUrl,
+                   success: { (playlist) in
+                    print("asych:\n\(playlist)")
+                    },
+                    failure: { (error) in
+                        print(error)
+                    })
+
+//: [Next](@next)

--- a/mambaPlayground.playground/Pages/Parsing a playlist.xcplaygroundpage/Contents.swift
+++ b/mambaPlayground.playground/Pages/Parsing a playlist.xcplaygroundpage/Contents.swift
@@ -2,7 +2,7 @@ import Foundation
 import mamba
 
 /*: # Parsing a playlist
- In General to parse a playlist you'll need: a `HLSParser`, the source of HLS `Data`, and the `URL` of the playlist resource. */
+ To parse a playlist you'll need: a `HLSParser`, the source of HLS `Data`, and the `URL` of the playlist resource. */
 let parser = HLSParser()
 let playlistData: Data = SamplePlaylist.master
 let playlistUrl: URL = URL(string: "http://nowhere")!

--- a/mambaPlayground.playground/Pages/Reading a playlist.xcplaygroundpage/Contents.swift
+++ b/mambaPlayground.playground/Pages/Reading a playlist.xcplaygroundpage/Contents.swift
@@ -1,0 +1,28 @@
+//: [Previous](@previous)
+import Foundation
+import mamba
+
+let masterPlaylist: HLSPlaylist = ParsedHLSPlaylists.master
+let variantPlaylist: HLSPlaylist = ParsedHLSPlaylists.variant
+/*: # Reading a playlist
+ The `HLSPlaylist` struct is an in memory representation of a HLS playlist. It includes:
+ The `URL` of the playlist*/
+let url: URL = masterPlaylist.url
+print("url:\(url)")
+//: An editable array of `HLSTag`s that represent each line in the playlist.
+let tags: [HLSTag] = masterPlaylist.tags
+print(tags.prettyPrint)
+//: utility functions to tell if a playlist is a master or variant, live, event or vod
+let fileType: FileType = variantPlaylist.type //media
+let playlistType: PlaylistType = variantPlaylist.playlistType //vod
+
+//: helper functions for the structure of a playlist
+let header: TagGroup = variantPlaylist.header! //returns references to all the header tags in the playlist
+print("header " + variantPlaylist.tags(forMediaGroup: header).prettyPrint)
+
+let footer: TagGroup = variantPlaylist.footer! //returns references to all footer tags in the playlist
+print("footer " + variantPlaylist.tags(forMediaGroup: footer).prettyPrint)
+
+let media: [MediaSegmentTagGroup] = variantPlaylist.mediaSegmentGroups //returns references to all media segments
+print("media " + variantPlaylist.tags(forMediaGroup: media[0]).prettyPrint)
+//: [Next](@next)

--- a/mambaPlayground.playground/Sources/SupportClasses.swift
+++ b/mambaPlayground.playground/Sources/SupportClasses.swift
@@ -1,0 +1,84 @@
+import Foundation
+import mamba
+public struct SamplePlaylist {
+    public static let master:Data = "#EXTM3U\n#EXT-X-VERSION:6\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2855600,CODECS=\"avc1.4d001f,mp4a.40.2\",RESOLUTION=960x540\nlive/medium.m3u8\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=5605600,CODECS=\"avc1.640028,mp4a.40.2\",RESOLUTION=1280x720\nlive/high.m3u8".data(using:.utf8)!
+    public static let variant:Data = "#EXTM3U\n#EXT-X-VERSION:4\n#EXT-X-I-FRAMES-ONLY\n#EXT-X-PLAYLIST-TYPE:VOD\n#EXT-X-ALLOW-CACHE:NO\n#EXT-X-TARGETDURATION:10\n#EXT-X-MEDIA-SEQUENCE:1\n#EXT-X-PROGRAM-DATE-TIME:2016-02-19T14:54:23.031+08:00\n#EXT-X-INDEPENDENT-SEGMENTS\n#EXT-X-START:TIME-OFFSET=0\n#EXT-X-KEY:METHOD=NONE\n#EXTINF:5220,1\nhttp://media.example.com/entire.ts\n#EXT-X-DISCONTINUITY\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"https://priv.example.com/key.php?r=52\",IV=0x9c7db8778570d05c3177c349fd9236aa,KEYFORMAT=\"com.apple.streamingkeydelivery\",KEYFORMATVERSIONS=\"1\"\n#EXTINF:5220,2\n#EXT-X-BYTERANGE:82112@752321\nhttp://media.example.com/entire1.ts\n#EXT-X-ENDLIST".data(using:.utf8)!
+    public static let masterWithCustomTag:Data = "#EXTM3U\n#EXT-X-CUSTOM\n#EXT-X-VERSION:6\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=2855600,CODECS=\"avc1.4d001f,mp4a.40.2\",RESOLUTION=960x540\nlive/medium.m3u8\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=5605600,CODECS=\"avc1.640028,mp4a.40.2\",RESOLUTION=1280x720\nlive/high.m3u8".data(using:.utf8)!
+}
+
+public struct ParsedHLSPlaylists {
+    public static let master:HLSPlaylist = {
+        let parser = HLSParser()
+        return try! parser.parse(playlistData:SamplePlaylist.master, url:URL(string:"http://nowhere")!) 
+    }()
+    
+    public static let variant:HLSPlaylist = {
+        let parser = HLSParser()
+        return try! parser.parse(playlistData:SamplePlaylist.variant, url:URL(string:"http://nowhere")!)
+    }()
+}
+
+public extension Sequence where Iterator.Element == HLSTag {
+    public var prettyPrint: String {
+        get {
+            var string = "tags:\n"
+            self.forEach { (tag) in
+                string += String("\(tag)\n")
+            }
+            return string
+        }
+    }
+}
+
+public enum CustomTag: String {
+    
+    case EXT_X_CUSTOM = "EXT-X-CUSTOM"
+}
+
+extension CustomTag: HLSTagDescriptor, Equatable {
+    
+    public static func constructTag(tag: String) -> HLSTagDescriptor? {
+        return CustomTag(rawValue: tag)
+    }
+    
+    public func toString() -> String {
+        return self.rawValue
+    }
+    
+    public func isEqual(toTagDescriptor tagDescriptor: HLSTagDescriptor) -> Bool {
+        guard let ourtag = tagDescriptor as? CustomTag else {
+            return false
+        }
+        return ourtag.rawValue == self.rawValue
+    }
+    
+    public func scope() -> HLSTagDescriptorScope {
+        return .mediaSegment
+    }
+    
+    public static func parser(forTag tag: HLSTagDescriptor) -> HLSTagParser? {
+        guard let ourtag = CustomTag(rawValue: tag.toString()) else {
+            return nil
+        }
+        
+        return GenericDictionaryTagParser(tag: ourtag)
+    }
+    
+    public static func writer(forTag tag: HLSTagDescriptor) -> HLSTagWriter? {
+        return nil
+    }
+    
+    public static func validator(forTag tag: HLSTagDescriptor) -> HLSTagValidator? {
+        return nil
+    }
+    
+    public func type() -> HLSTagDescriptorType {
+        return .noValue
+    }
+    
+    public static func constructDescriptor(fromStringRef string: HLSStringRef) -> HLSTagDescriptor? {
+        var tagName = string.stringValue()
+        tagName.remove(at: tagName.startIndex)
+        return constructTag(tag: tagName)
+    }
+}

--- a/mambaPlayground.playground/contents.xcplayground
+++ b/mambaPlayground.playground/contents.xcplayground
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios' display-mode='raw' executeOnSourceChanges='false'>
+    <pages>
+        <page name='Parsing a playlist'/>
+        <page name='Reading a playlist'/>
+        <page name='Editing a playlist'/>
+    </pages>
+</playground>


### PR DESCRIPTION
Addresses issue #15 

### Description

Add a playground to mamba to demo basic functionality and give users a place to test/practice using the framework. @dcoufal let me know if there are any cases you think I missed that should be in this demo.

### Change Notes

* Parsing a playlist, reading a playlist, and editing playlist sections with markdown style notes.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

