### PR TITLE
Make `GenericSingleTagWriter` public, like all the other generic writers/parsers/validators

### DIFF
--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Writers/GenericSingleTagWriter.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Writers/GenericSingleTagWriter.swift
@@ -20,15 +20,15 @@
 import Foundation
 
 /// Generic writer for HLS tags that have just one single value (e.g. `#EXT-X-TARGETDURATION:10`)
-struct GenericSingleTagWriter: HLSTagWriter {
+public struct GenericSingleTagWriter: HLSTagWriter {
     
     fileprivate let singleTagValueIdentifier: HLSTagValueIdentifier
     
-    init(singleTagValueIdentifier: HLSTagValueIdentifier) {
+    public init(singleTagValueIdentifier: HLSTagValueIdentifier) {
         self.singleTagValueIdentifier = singleTagValueIdentifier
     }
     
-    func write(tag: HLSTag, toStream stream: OutputStream) throws {
+    public func write(tag: HLSTag, toStream stream: OutputStream) throws {
         
         guard tag.keys.count == 1 else {
             throw OutputStreamError.invalidData(description:"\(tag.tagDescriptor.toString()) Tag requires a \(singleTagValueIdentifier.toString()) value. Found \(tag.keys.count) values instead. Keys found: \(tag.keys)")


### PR DESCRIPTION
### Change Notes

* Make `GenericSingleTagWriter` public, like all the other generic writers/parsers/validators
* Needed to allow adding custom `HLSTagDescriptor`s

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

