### PR TITLE
Adding support for updating Event-style playlists efficiently when they are very large

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -71,6 +71,10 @@
 		EC03B6731E5CC56B00BF1F97 /* RapidParserStateHandlers.h in Headers */ = {isa = PBXBuildFile; fileRef = EC03B6511E5CC56B00BF1F97 /* RapidParserStateHandlers.h */; };
 		EC0677DC21641FE500E715D1 /* CMTimeMakeFromStringCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0677DB21641FE500E715D1 /* CMTimeMakeFromStringCTests.m */; };
 		EC0677DD21641FE500E715D1 /* CMTimeMakeFromStringCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0677DB21641FE500E715D1 /* CMTimeMakeFromStringCTests.m */; };
+		EC0677DE2165753500E715D1 /* CMTimeMakeFromStringCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0677DB21641FE500E715D1 /* CMTimeMakeFromStringCTests.m */; };
+		EC0677E02166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0677DF2166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift */; };
+		EC0677E12166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0677DF2166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift */; };
+		EC0677E22166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0677DF2166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift */; };
 		EC073F571FE0572400689228 /* HLSTagCriterionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC073F561FE0572400689228 /* HLSTagCriterionTests.swift */; };
 		EC073F581FE0572400689228 /* HLSTagCriterionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC073F561FE0572400689228 /* HLSTagCriterionTests.swift */; };
 		EC073F5A1FE072DC00689228 /* HLSTagCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC073F591FE072DC00689228 /* HLSTagCollectionTests.swift */; };
@@ -636,6 +640,7 @@
 		EC03B6501E5CC56B00BF1F97 /* RapidParserStateHandlers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = RapidParserStateHandlers.c; sourceTree = "<group>"; };
 		EC03B6511E5CC56B00BF1F97 /* RapidParserStateHandlers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RapidParserStateHandlers.h; sourceTree = "<group>"; };
 		EC0677DB21641FE500E715D1 /* CMTimeMakeFromStringCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMTimeMakeFromStringCTests.m; sourceTree = "<group>"; };
+		EC0677DF2166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HLSParser_EventUpdateTests.swift; sourceTree = "<group>"; };
 		EC073F561FE0572400689228 /* HLSTagCriterionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HLSTagCriterionTests.swift; sourceTree = "<group>"; };
 		EC073F591FE072DC00689228 /* HLSTagCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HLSTagCollectionTests.swift; sourceTree = "<group>"; };
 		EC073F5C1FE0840000689228 /* OutputStreamExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStreamExtensionTests.swift; sourceTree = "<group>"; };
@@ -961,16 +966,17 @@
 			children = (
 				EC6C8F821D08C78C007C1C99 /* Fixtures */,
 				EC6C8F831D08C793007C1C99 /* Helpers */,
+				43DE4EFE1E564E1500EEE800 /* HLSMediaSpanTests.swift */,
+				EC0677DF2166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift */,
+				EC7492351DD29E7300AF4E20 /* HLSParser_Super8DemuxedTests.swift */,
+				EC7492361DD29E7300AF4E20 /* HLSParser_Super8MuxedTests.swift */,
+				EC7492371DD29E7300AF4E20 /* HLSParserTest.swift */,
 				EC6F38911EA95882006BC30E /* HLSPlaylistInterfaceTests.swift */,
 				EC37A8D61E9C16C7005E8342 /* HLSPlaylistStructureAndEditingTests.swift */,
 				4367C3721EAE83C000685945 /* HLSPlaylistStructureMasterTests.swift */,
 				ECC410691EA1687500B4E3C8 /* HLSPlaylistStructureTests.swift */,
 				EC402B921F7D5A8B00730C74 /* HLSPlaylistTests.swift */,
 				ECE36DE31F2A9F10005E5DA7 /* HLSPlaylistTimelineAndSequencingTests.swift */,
-				43DE4EFE1E564E1500EEE800 /* HLSMediaSpanTests.swift */,
-				EC7492351DD29E7300AF4E20 /* HLSParser_Super8DemuxedTests.swift */,
-				EC7492361DD29E7300AF4E20 /* HLSParser_Super8MuxedTests.swift */,
-				EC7492371DD29E7300AF4E20 /* HLSParserTest.swift */,
 				883290551EA172170064588B /* HLSStringRefExtensionTests.swift */,
 				EC073F591FE072DC00689228 /* HLSTagCollectionTests.swift */,
 				EC073F561FE0572400689228 /* HLSTagCriterionTests.swift */,
@@ -1825,6 +1831,7 @@
 				EC74928A1DD29F1500AF4E20 /* GenericDictionaryTagValidatorTests.swift in Sources */,
 				EC073F601FE08F7500689228 /* String+Helio.swift in Sources */,
 				EC74922C1DD29E4A00AF4E20 /* HLSPlaylist+Convenience.swift in Sources */,
+				EC0677E02166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift in Sources */,
 				EC7492B71DD29F8900AF4E20 /* HLSPlaylistTypeTests.swift in Sources */,
 				ECFBD9101E5CCC2200379FC2 /* ParseArrayTests.m in Sources */,
 				EC7492B31DD29F8900AF4E20 /* HLSCodecArrayTests.swift in Sources */,
@@ -1984,6 +1991,7 @@
 				EC74924B1DD29E7300AF4E20 /* HLSWriterTests.swift in Sources */,
 				EC073F611FE08F7500689228 /* String+Helio.swift in Sources */,
 				EC74928B1DD29F1500AF4E20 /* GenericDictionaryTagValidatorTests.swift in Sources */,
+				EC0677E12166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift in Sources */,
 				EC74922D1DD29E4A00AF4E20 /* HLSPlaylist+Convenience.swift in Sources */,
 				ECFBD9111E5CCC2200379FC2 /* ParseArrayTests.m in Sources */,
 				EC7492B81DD29F8900AF4E20 /* HLSPlaylistTypeTests.swift in Sources */,
@@ -2117,6 +2125,7 @@
 				ECE253E1209A509900D388CE /* HLSTagCollectionTests.swift in Sources */,
 				ECE253DD209A509900D388CE /* HLSParser_Super8DemuxedTests.swift in Sources */,
 				ECE253DC209A509900D388CE /* HLSMediaSpanTests.swift in Sources */,
+				EC0677DE2165753500E715D1 /* CMTimeMakeFromStringCTests.m in Sources */,
 				ECE253E7209A509900D388CE /* HLSWriterTests.swift in Sources */,
 				ECE253D1209A509000D388CE /* FixtureLoader.swift in Sources */,
 				ECE253D2209A509000D388CE /* HLSPlaylist+Convenience.swift in Sources */,
@@ -2142,6 +2151,7 @@
 				ECE253FE209A50B500D388CE /* CMTimeMakeFromStringTests.swift in Sources */,
 				ECE253D9209A509900D388CE /* HLSPlaylistStructureTests.swift in Sources */,
 				ECE253EC209A50A100D388CE /* RapidParserTests.swift in Sources */,
+				EC0677E22166C7CC00E715D1 /* HLSParser_EventUpdateTests.swift in Sources */,
 				ECE253FC209A50B500D388CE /* GenericSingleTagWriterTests.swift in Sources */,
 				ECE253DA209A509900D388CE /* HLSPlaylistTests.swift in Sources */,
 				ECE253F4209A50B500D388CE /* EXT_X_PROGRAM_DATE_TIMEParserTests.swift in Sources */,

--- a/mambaSharedFramework/HLS Models/HLSPlaylist.swift
+++ b/mambaSharedFramework/HLS Models/HLSPlaylist.swift
@@ -34,7 +34,7 @@ public extension HLSPlaylistCore where T == HLSPlaylistURLData {
         self.init(url: playlist.url, tags: playlist.tags, registeredTags: playlist.registeredTags, hlsData: playlist.hlsData)
     }
 
-    // care should be taken when constructing `HLSPlaylist` manually. Most users should construct these objects using `HLSParser`
+    // care should be taken when constructing `HLSPlaylist` manually. Users should construct these objects using `HLSParser`
     public init(url: URL, tags: [HLSTag], registeredTags: RegisteredHLSTags, hlsData: Data) {
         let customData = HLSPlaylistURLData(url: url)
         self.init(tags: tags, registeredTags: registeredTags, hlsData: hlsData, customData: customData)
@@ -50,12 +50,20 @@ public extension HLSPlaylistCore where T == HLSPlaylistURLData {
         }
     }
     
+    /// The time this playlist was created. Based on `CACurrentMediaTime`, so only comparable with that time system.
+    public var creationTime: TimeInterval {
+        get {
+            return customData.creationTime
+        }
+    }
+    
     public var debugDescription: String {
-        return "HLSPlaylist url:\(url)\n\(self.playlistCoreDebugDescription)"
+        return "HLSPlaylist url:\(url) createTime:\(creationTime)\n\(self.playlistCoreDebugDescription)"
     }
 }
 
 /// A type used internally by HLSPlaylist
 public struct HLSPlaylistURLData {
     var url: URL
+    let creationTime = CACurrentMediaTime()
 }

--- a/mambaSharedFramework/HLS Rapid Parser/HLSRapidParser.m
+++ b/mambaSharedFramework/HLS Rapid Parser/HLSRapidParser.m
@@ -42,7 +42,7 @@
                           endTagData:(UInt64)endRemainingTagData;
 - (void)newCommentWithStart:(UInt64)startComment
                         end:(UInt64)endComment;
-- (void)newURLWithStart:(UInt64)startURL
+- (BOOL)newURLWithStart:(UInt64)startURL
                     end:(UInt64)endURL;
 - (void)parseComplete;
 - (void)parseError:(NSString *)errorString
@@ -83,9 +83,9 @@ void NewCommentCallback(const void *parentparser, const uint64_t startComment, c
     [parser newCommentWithStart:startComment end:endComment];
 }
 
-void NewURLCallback(const void *parentparser, const uint64_t startURL, const uint64_t endURL) {
+bool NewURLCallback(const void *parentparser, const uint64_t startURL, const uint64_t endURL) {
     HLSRapidParser *parser = (__bridge HLSRapidParser *)(parentparser);
-    [parser newURLWithStart:startURL end:endURL];
+    return [parser newURLWithStart:startURL end:endURL] == YES;
 }
 
 void ParseComplete(const void *parentparser) {
@@ -186,12 +186,12 @@ void ParseError(const void *parentparser, const uint32_t errorNum, const char *e
     [self.callback addedCommentLine:comment];
 }
 
-- (void)newURLWithStart:(UInt64)startURL
+- (BOOL)newURLWithStart:(UInt64)startURL
                     end:(UInt64)endURL {
     
     HLSStringRef *url = [[HLSStringRef alloc] initWithBytesNoCopy:[self.data bytes] + startURL length:(NSUInteger)(endURL - startURL + 1)];
         
-    [self.callback addedURLLine:url];
+    return [self.callback addedURLLine:url];
 }
 
 - (void)parseComplete {

--- a/mambaSharedFramework/HLS Rapid Parser/HLSRapidParserCallback.h
+++ b/mambaSharedFramework/HLS Rapid Parser/HLSRapidParserCallback.h
@@ -24,7 +24,7 @@
 @protocol HLSRapidParserCallback <NSObject>
 
 - (void)addedCommentLine:(HLSStringRef * _Nonnull)comment;
-- (void)addedURLLine:(HLSStringRef * _Nonnull)url;
+- (BOOL)addedURLLine:(HLSStringRef * _Nonnull)url;
 - (void)addedNoValueTagWithName:(HLSStringRef * _Nonnull)tagName;
 - (void)addedTagWithName:(HLSStringRef * _Nonnull)tagName
                    value:(HLSStringRef * _Nonnull)value;

--- a/mambaSharedFramework/HLS Rapid Parser/RapidParser.c
+++ b/mambaSharedFramework/HLS Rapid Parser/RapidParser.c
@@ -35,24 +35,25 @@ void parseHLS(const void *parentparser, const unsigned char *bytes, const uint64
     
     rapid_parser_debug_print("Begining parse of hls data with length %llu\n", length);
     
-    while (index > 0 && state != ErrorEarlyExit) {
+    while (index > 0 && state < numberOfScanningParseStates) {
         
         index -= 1;
         
         state = (*masterParseArray[state][bytes[index]]) (parentparser, bytes[index], index, state, &lineState);
         
         rapid_parser_debug_print("State %i after processing character %c at index %llu\n", (int)state, bytes[index], index);
-        
     }
     
-    if (index == 0 && state != ErrorEarlyExit) {
+    // if we are in ErrorEarlyExit or EarlyExit we do not have to handle the final line
+    if (index == 0 && state < numberOfScanningParseStates) {
         // handle the final line, force a line completion
         // note that we pass "-1" as the index, because we are pretending that there is a newline at position -1
         (*masterParseArray[state]['\n']) (parentparser, '\n', -1, state, &lineState);
     }
     
     // if we are in ErrorEarlyExit another part of the code already called ParseError to exit out
-    if (state != ErrorEarlyExit) {
+    // if we are in EarlyExit, its because the client has asked us to exit and they know that parsing is complete
+    if (state < numberOfScanningParseStates) {
         
         rapid_parser_debug_print("Ending parse of hls data with length %llu\n", length);
         

--- a/mambaSharedFramework/HLS Rapid Parser/RapidParserNewTagCallbacks.h
+++ b/mambaSharedFramework/HLS Rapid Parser/RapidParserNewTagCallbacks.h
@@ -20,11 +20,14 @@
 #ifndef RapidParserCallback_h
 #define RapidParserCallback_h
 
+#include <stdbool.h>
+
 void NewTagCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName, const uint64_t startTagData, const uint64_t endTagData);
 void NewTagNoDataCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName);
 void NewEXTINFTagNoDataCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName, const uint64_t startDuration, const uint64_t endDuration, const uint64_t startTagData, const uint64_t endTagData);
 void NewCommentCallback(const void *parentparser, const uint64_t startComment, const uint64_t endComment);
-void NewURLCallback(const void *parentparser, const uint64_t startURL, const uint64_t endURL);
+// return true to NewURLCallback to continue scanning, false to trigger an early exit and stop the parse
+bool NewURLCallback(const void *parentparser, const uint64_t startURL, const uint64_t endURL);
 void ParseComplete(const void *parentparser);
 void ParseError(const void *parentparser, const uint32_t errorNum, const char *errorString);
 

--- a/mambaSharedFramework/HLS Rapid Parser/RapidParserState.h
+++ b/mambaSharedFramework/HLS Rapid Parser/RapidParserState.h
@@ -49,6 +49,8 @@ enum ParseState {
     LookingForHashForEXTINF,
     // when we find a #, we start looking for a newline to possibly complete a #EXTINF and make a tag
     LookingForNewlineForEXTINF,
+    // signal an early exit (not an error, but the client has requested a stop scanning) (THIS NEEDS TO BE SECOND TO LAST IN THE PARSE STATE LIST)
+    EarlyExit,
     // when we encounter an error, signal an early exit (THIS NEEDS TO BE LAST IN THE PARSE STATE LIST)
     ErrorEarlyExit
 };

--- a/mambaSharedFramework/HLS Rapid Parser/RapidParserStateHandlers.c
+++ b/mambaSharedFramework/HLS Rapid Parser/RapidParserStateHandlers.c
@@ -63,10 +63,10 @@ uint8_t endOfLineForURLAndContinueScanning(const void *parentparser, const unsig
         lineState->end = index - 1;
         return Scanning;
     }
-    NewURLCallback(parentparser, lineState->start, lineState->end);
+    bool shouldContinue = NewURLCallback(parentparser, lineState->start, lineState->end);
     initializeLineState(lineState);
     lineState->end = index - 1;
-    return Scanning;
+    return shouldContinue ? Scanning : EarlyExit;
 }
 
 // Scanning Handlers for LookingForX state
@@ -195,6 +195,5 @@ uint8_t foundNewlineCompletingEXTINFBeginAndContinueScanning(const void *parentp
     initializeLineState(lineState);
     lineState->end = index - 1;
     return Scanning;
-
 }
 

--- a/mambaSharedFramework/HLSParser.swift
+++ b/mambaSharedFramework/HLSParser.swift
@@ -18,6 +18,7 @@ import Foundation
 public final class HLSParser {
     
     internal fileprivate(set) var registeredTags = RegisteredHLSTags()
+    internal let updateEventPlaylistParams: UpdateEventPlaylistParams
     
     /**
      Constructs a parser for HLS playlists.
@@ -26,8 +27,14 @@ public final class HLSParser {
      would like this parser to parse. If you have custom tags that you'd like to easily
      identify and query on, the caller can construct their own `HLSTagDescriptor`-implementing
      object and pass in the type here.
+     - parameter updateEventPlaylistParams: An optional struct with parameters for desired
+     behavior when updating an Event style variant playlist. See `UpdateEventPlaylistParams`
+     for details. If you are uncertain, the defaults are probably good. Mostly present for
+     unit testing purposes.
      */
-    public init(tagTypes:[HLSTagDescriptor.Type]? = nil) {
+    public init(tagTypes:[HLSTagDescriptor.Type]? = nil,
+                updateEventPlaylistParams: UpdateEventPlaylistParams = UpdateEventPlaylistParams()) {
+        self.updateEventPlaylistParams = updateEventPlaylistParams
         if let tagTypes = tagTypes {
             for tagType in tagTypes {
                 registerHLSTags(tagType: tagType)
@@ -118,6 +125,101 @@ public final class HLSParser {
                          customData: HLSPlaylistURLData(url: url),
                          hlsPlaylistConstructor: constructHLSPlaylist)
     }
+    
+    public func update(eventVariantPlaylist: HLSPlaylist,
+                       withPlaylistData data: Data,
+                       atUrl url: URL,
+                       withSuccessCallback success: @escaping HLSPlaylistParserSuccess,
+                       withFailureCallback failure: @escaping HLSPlaylistParserFailure) {
+        
+        guard
+            // sanity checks on the caller
+            eventVariantPlaylist.type == .media,
+            eventVariantPlaylist.playlistType == .event,
+            // have to update the exact same variant!
+            url == eventVariantPlaylist.url,
+            // check to see if this situation merits an update vs a parse
+            data.count > updateEventPlaylistParams.minimalBytesToTriggerUpdate,
+            (CACurrentMediaTime() - eventVariantPlaylist.creationTime) < updateEventPlaylistParams.maximumAmountOfTimeBetweenUpdatesToTrigger,
+            // ensure we can get the data we need to do an update
+            let lastMediaSegmentGroup = eventVariantPlaylist.mediaSegmentGroups.last,
+            let lastFragmentTag = eventVariantPlaylist.tags(forMediaGroup: lastMediaSegmentGroup).filter({ $0.tagDescriptor == PantosTag.Location }).first,
+            !lastFragmentTag.tagData.stringValue().isEmpty else {
+                
+                // if we fail preconditions just do a normal parse quietly
+                parse(playlistData: data, url: url, success: success, failure: failure)
+                return
+        }
+        
+        let worker = HLSParseWorker(registeredTags: registeredTags,
+                                    data: data,
+                                    parser: self,
+                                    parserMode: .parsingEventPlaylistLookingForFragmentURL(fragmentURL: lastFragmentTag.tagData.stringValue()),
+                                    success: { [weak self] (tags) in
+                                        self?.constructAndReturnEventVariantUpdate(fromEventVariantPlaylist: eventVariantPlaylist,
+                                                                                   insertingNewTags: tags,
+                                                                                   afterTagPosition: lastMediaSegmentGroup.endIndex,
+                                                                                   withSuccessCallback: success) },
+                                    failure: { [weak self] _ in
+                                        // try a normal parse
+                                        self?.parse(playlistData: data, url: url, success: success, failure: failure) })
+        
+        queue.sync {
+            let _ = workers.insert(worker)
+        }
+        
+        worker.startParse()
+    }
+    
+    private func constructAndReturnEventVariantUpdate(fromEventVariantPlaylist eventVariantPlaylist: HLSPlaylist,
+                                                      insertingNewTags newTags: [HLSTag],
+                                                      afterTagPosition insertTagPosition: Int,
+                                                      withSuccessCallback success: @escaping HLSPlaylistParserSuccess) {
+        
+        var tags = eventVariantPlaylist.tags[0...insertTagPosition]
+        tags.append(contentsOf: newTags)
+        let newPlaylist = HLSPlaylist(url: eventVariantPlaylist.url,
+                                      tags: Array(tags),
+                                      registeredTags: registeredTags,
+                                      hlsData: eventVariantPlaylist.hlsData)
+        success(newPlaylist)
+    }
+
+    public func update(eventVariantPlaylist: HLSPlaylist,
+                       withPlaylistData data: Data,
+                       atUrl url: URL,
+                       withTimeout timeout: Int = 1) throws -> HLSPlaylist {
+        
+        let semaphore = DispatchSemaphore(value: 0)
+        var playlist: HLSPlaylist?
+        var error: HLSParserError?
+        
+        self.update(eventVariantPlaylist: eventVariantPlaylist,
+                    withPlaylistData: data,
+                    atUrl: url,
+                    withSuccessCallback: { (newPlaylist) -> (Void) in
+                        playlist = newPlaylist
+                        semaphore.signal() },
+                    withFailureCallback: { (result) -> (Void) in
+                        error = result
+                        semaphore.signal() })
+        
+        if semaphore.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(timeout)) == .timedOut {
+            throw HLSParserError.timedOut
+        }
+        
+        if let error = error {
+            throw error
+        }
+        
+        guard let result = playlist else {
+            assertionFailure("No error, but playlist was nil!")
+            throw HLSParserError.unknown(description: "No error found, but no playlist was generated.")
+        }
+        
+        return result
+    }
+
     
     /**
      Generic parser for your concrete `HLSPlaylistCore` objects, if you need one. Most
@@ -254,6 +356,44 @@ public typealias HLSPlaylistParserFailure = (HLSParserError) -> (Swift.Void)
 public typealias HLSParserSuccess = ([HLSTag]) -> (Swift.Void)
 public typealias HLSParserFailure = (HLSParserError) -> (Swift.Void)
 
+/**
+ This stores detailed info about when mamba decides to trigger a update of a event style
+ variant (rather than just reparse from scratch).
+ 
+ The defaults are probably good for general usage, although if your application has
+ unusual or special requirements for Event style playlists, you can change. This is here
+ mostly for unit testing.
+ */
+public struct UpdateEventPlaylistParams {
+    /**
+     Parsing of small playlists is very quick, so it doesn't really make sense to do anything
+     special for them.
+     
+     The default value was chosen to approximate a 150 segment long playlist.
+     */
+    let minimalBytesToTriggerUpdate: Int
+    /**
+     If the difference between the last time the playlist was created/updated and the
+     current time is more than this value, HLSParser will do a complete parse.
+
+     
+     Why? If the difference between the playlist to be updated and the new playlist is too big,
+     the update process can actually be longer than the complete reparse (since the update
+     process allocates new memory in small chunks for new data)
+     
+     The default value is 60 seconds. If your fragment length is very big, you might want this
+     value to be bigger, and if your fragment length is very small, you might want this to be
+     smaller.
+     */
+    let maximumAmountOfTimeBetweenUpdatesToTrigger: TimeInterval
+    
+    public init(minimalBytesToTriggerUpdate: Int = 20000,
+                maximumAmountOfTimeBetweenUpdatesToTrigger: TimeInterval = 60) {
+        self.minimalBytesToTriggerUpdate = minimalBytesToTriggerUpdate
+        self.maximumAmountOfTimeBetweenUpdatesToTrigger = maximumAmountOfTimeBetweenUpdatesToTrigger
+    }
+}
+
 private func constructHLSPlaylist(withTags tags: [HLSTag], customData: HLSPlaylistURLData, registeredHLSTags: RegisteredHLSTags, hlsData: Data) -> HLSPlaylist {
     return HLSPlaylist(tags: tags, registeredTags: registeredHLSTags, hlsData: hlsData, customData: customData)
 }
@@ -263,20 +403,26 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
     let fastParser = HLSRapidParser()
     var tags = [HLSTag]()
     let data: Data
-    weak var parser: HLSParser?
+    // strong ref to parent parser while parsing is happening
+    // we release when parsing is over to prevent retain cycles
+    // see `parseFail, `parseSuccess` and `parseEventUpdateSuccess` for where we do that.
+    var parser: HLSParser?
     let registeredTags: RegisteredHLSTags
     var success: HLSParserSuccess
     var failure: HLSParserFailure
+    let parserMode: ParseWorkerMode
     
     init(registeredTags: RegisteredHLSTags,
          data: Data,
          parser: HLSParser,
+         parserMode: ParseWorkerMode = .parsingFromScratch,
          success: @escaping HLSParserSuccess,
          failure: @escaping HLSParserFailure) {
         
         self.data = data
         self.parser = parser
         self.registeredTags = registeredTags
+        self.parserMode = parserMode
         self.success = success
         self.failure = failure
     }
@@ -284,29 +430,58 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
     func startParse() {
         fastParser.parseHLSData(self.data, callback: self)
     }
+    
+    private func scrubHLSStringRef(_ ref: HLSStringRef) -> HLSStringRef {
+        switch self.parserMode {
+        case .parsingFromScratch:
+            return ref
+        case .parsingEventPlaylistLookingForFragmentURL(_):
+            // if we are parsing through an Event update, we want to only keep the original `Data` from the first parse
+            // so we convert new updates to strings. This is an optimistic assumption that we only have a few
+            // updated tags and the cost of converting the small number to strings will be small.
+            return HLSStringRef(string: ref.stringValue())
+        }
+    }
 
     // MARK: HLSRapidParserCallback
     
     func addedCommentLine(_ comment: HLSStringRef) {
-        tags.append(HLSTag(tagDescriptor: PantosTag.Comment, tagData: comment))
+        tags.append(HLSTag(tagDescriptor: PantosTag.Comment, tagData: scrubHLSStringRef(comment)))
     }
     
-    func addedURLLine(_ url: HLSStringRef) {
-        tags.append(HLSTag(tagDescriptor: PantosTag.Location, tagData: url))
+    func addedURLLine(_ url: HLSStringRef) -> Bool {
+        switch self.parserMode {
+        case .parsingFromScratch:
+            tags.append(HLSTag(tagDescriptor: PantosTag.Location, tagData: url))
+            return true
+        case .parsingEventPlaylistLookingForFragmentURL(let alreadyParsedFragmentURL):
+            let urlString = url.stringValue()
+            if alreadyParsedFragmentURL == urlString {
+                if let error = parseError {
+                    parseFail(error: error)
+                }
+                else {
+                    parseEventUpdateSuccess()
+                }
+                return false
+            }
+            tags.append(HLSTag(tagDescriptor: PantosTag.Location, tagData: HLSStringRef(string: urlString)))
+            return true
+        }
     }
     
     func addedNoValueTag(withName tagName: HLSStringRef) {
         let descriptor = tagDescriptor(forTagName: tagName)
         guard descriptor != PantosTag.UnknownTag else {
             // special case handling for unknown tags
-            tags.append(HLSTag(tagDescriptor: descriptor, tagData: HLSStringRef(), tagName: tagName))
+            tags.append(HLSTag(tagDescriptor: descriptor, tagData: HLSStringRef(), tagName: scrubHLSStringRef(tagName)))
             return
         }
         guard descriptor.type() == .noValue else {
             parseError = HLSParserError.mismatchBetweenTagDescriptorAndTagData(description:"The HLS Tag and the data contained within do not match: tagName:\"\(tagName.stringValue())\" tagValue:<no tag value> descriptor:\(descriptor)")
             return
         }
-        tags.append(HLSTag(tagDescriptor: descriptor, tagData: HLSStringRef(), tagName: tagName))
+        tags.append(HLSTag(tagDescriptor: descriptor, tagData: HLSStringRef(), tagName: scrubHLSStringRef(tagName)))
     }
     
     func addedTag(withName tagName: HLSStringRef, value: HLSStringRef) {
@@ -319,7 +494,7 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
         
         guard descriptor != PantosTag.UnknownTag else {
             // special case handling for unknown tags
-            tags.append(HLSTag(tagDescriptor: descriptor, tagData: value, tagName: tagName))
+            tags.append(HLSTag(tagDescriptor: descriptor, tagData: scrubHLSStringRef(value), tagName: scrubHLSStringRef(tagName)))
             return
         }
         
@@ -328,11 +503,11 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
             return
         }
         
-        tags.append(HLSTag(tagDescriptor: descriptor, tagData: value, tagName: tagName, parsedValues: parsedValues))
+        tags.append(HLSTag(tagDescriptor: descriptor, tagData: scrubHLSStringRef(value), tagName: scrubHLSStringRef(tagName), parsedValues: parsedValues))
     }
     
     func addedEXTINFTag(withName tagName: HLSStringRef, duration: HLSStringRef, value: HLSStringRef) {
-        tags.append(HLSTag(tagDescriptor: PantosTag.EXTINF, tagData: value, tagName: tagName, duration: duration.extinfSegmentDuration()))
+        tags.append(HLSTag(tagDescriptor: PantosTag.EXTINF, tagData: scrubHLSStringRef(value), tagName: scrubHLSStringRef(tagName), duration: duration.extinfSegmentDuration()))
     }
     
     func parseComplete() {
@@ -373,11 +548,20 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
     private func parseFail(error: HLSParserError) {
         failure(error)
         parser?.parseComplete(withWorker: self)
+        parser = nil
     }
     
     private func parseSucceed(tags: [HLSTag]) {
         success(tags)
         parser?.parseComplete(withWorker: self)
+        parser = nil
+    }
+    
+    private func parseEventUpdateSuccess() {
+        tags = tags.reversed()
+        success(tags)
+        parser?.parseComplete(withWorker: self)
+        parser = nil
     }
     
     private func parseTags(tagValue: HLSStringRef, descriptor: HLSTagDescriptor) -> HLSTagDictionary? {
@@ -404,4 +588,35 @@ fileprivate final class HLSParseWorker: NSObject, HLSRapidParserCallback {
         }
         return PantosTag.UnknownTag
     }
+}
+
+/// The mode that this worker is set to run
+private enum ParseWorkerMode {
+    
+    /**
+     "Normal" mode.
+     
+     The parser will go through the data a line at a time and extract the entire HLS playlist.
+     */
+    case parsingFromScratch
+    
+    /**
+     "Event style variant" efficiency mode.
+     
+     With event style variant playlists, new fragments are added at the end of the playlist. Any fragments already sent are unchanged.
+     This is a HLS spec requirement. <https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-03#section-6.2.1>
+     
+     If you are parsing a event playlist that is hours long, it's a lot of work to parse a bunch of identical content over and over
+     for each playlist update.
+     
+     This mode sets the parse worker to look for the last fragment url that we found in the last update. Once found, we stop
+     parsing and return all the "new" tags. (Note that any tags in the "footer" will be reparsed every time).
+     
+     Further note that we actually allocate real memory for all tag strings that is not tied to the `Data` object that we are
+     parsing. It would become unworkable to keep track of the innumerable updates and which memory belongs to which `Data`.
+     
+     It's up to our parent HLSParser to set this mode with an eye towards performance and memory usage, and to deal with the
+     returned tags appropriately to construct a valid HLSPlaylist.
+     */
+    case parsingEventPlaylistLookingForFragmentURL(fragmentURL: String)
 }

--- a/mambaTests/HLSParser_EventUpdateTests.swift
+++ b/mambaTests/HLSParser_EventUpdateTests.swift
@@ -1,0 +1,291 @@
+//
+//  HLSParser_EventUpdateTests.swift
+//  mamba
+//
+//  Created by David Coufal on 10/4/18.
+//  Copyright © 2018 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import XCTest
+@testable import mamba
+
+class HLSParser_EventUpdateTests: XCTestCase {
+
+    let testURL1 = URL(string: "https://HLSParser_EventUpdateTests.nowhere/event_variant1.m3u8")!
+    let testURL2 = URL(string: "https://HLSParser_EventUpdateTests.nowhere/event_variant2.m3u8")!
+
+    func testEventVariantUpdateHappyPath() {
+        
+        // get an initial playlist
+        var event1 = parsePlaylist(inString: eventHLS1)
+        event1.url = testURL1
+        
+        XCTAssertEqual(event1.tags.count, 15)
+        
+        // create a special parser that will always do an update on event style variants
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 0,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 60 * 60))
+        let event2 = try! parser.update(eventVariantPlaylist: event1,
+                                        withPlaylistData: eventHLS2.data(using: .utf8)!,
+                                        atUrl: testURL1)
+        
+        XCTAssertEqual(event1.hlsData, event2.hlsData)
+        XCTAssertEqual(event2.tags.count, 19)
+        
+        let event3 = try! parser.update(eventVariantPlaylist: event2,
+                                        withPlaylistData: eventHLS3.data(using: .utf8)!,
+                                        atUrl: testURL1)
+        
+        XCTAssertEqual(event1.hlsData, event3.hlsData)
+        XCTAssertEqual(event3.tags.count, 27)
+    }
+
+    func testEventVariantUpdateHappyPath_NoChangeToPlaylist() {
+        
+        // get an initial playlist
+        var event1 = parsePlaylist(inString: eventHLS1)
+        event1.url = testURL1
+        
+        XCTAssertEqual(event1.tags.count, 15)
+        
+        // create a special parser that will always do an update on event style variants
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 0,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 60 * 60))
+        let event2 = try! parser.update(eventVariantPlaylist: event1,
+                                        withPlaylistData: eventHLS1.data(using: .utf8)!,
+                                        atUrl: testURL1)
+        
+        XCTAssertEqual(event1.hlsData, event2.hlsData)
+        XCTAssertEqual(event2.tags.count, 15)
+    }
+
+    func testEventVariantUpdateFailDueToSizeDifference() {
+        
+        // get an initial playlist
+        var event1 = parsePlaylist(inString: eventHLS1)
+        event1.url = testURL1
+        
+        XCTAssertEqual(event1.tags.count, 15)
+        
+        // create a special parser that will have a large playlist size required to trigger and update. this will fail the update on our small playlists
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 100000,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 60 * 60))
+        let event2 = try! parser.update(eventVariantPlaylist: event1,
+                                        withPlaylistData: eventHLS2.data(using: .utf8)!,
+                                        atUrl: testURL1)
+        
+        XCTAssertNotEqual(event1.hlsData, event2.hlsData)
+        XCTAssertEqual(event2.tags.count, 19)
+    }
+    
+    func testEventVariantUpdateFailDueToTooMuchTimePassingBetweenUpdates() {
+        
+        // get an initial playlist
+        var event1 = parsePlaylist(inString: eventHLS1)
+        event1.url = testURL1
+        
+        XCTAssertEqual(event1.tags.count, 15)
+        
+        // create a special parser that will have a very small 10 millisecond max time between updates before it will fail and just do a normal parse
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 0,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 0.010))
+        
+        usleep(20 * 1000) // sleep for 20 millseconds to trigger the failure
+        
+        let event2 = try! parser.update(eventVariantPlaylist: event1,
+                                        withPlaylistData: eventHLS2.data(using: .utf8)!,
+                                        atUrl: testURL1)
+        
+        XCTAssertNotEqual(event1.hlsData, event2.hlsData)
+        XCTAssertEqual(event2.tags.count, 19)
+    }
+
+    func testEventVariantUpdateFailDueToNonEventStylePlaylist() {
+        
+        // get an initial playlist
+        var vod1 = parsePlaylist(inString: vodHLS1)
+        vod1.url = testURL1
+        
+        XCTAssertEqual(vod1.tags.count, 11)
+        
+        // create a special parser that will always do an update on event style variants
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 0,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 60 * 60))
+        
+        let vod2 = try! parser.update(eventVariantPlaylist: vod1,
+                                      withPlaylistData: vodHLS2.data(using: .utf8)!,
+                                      atUrl: testURL1)
+        
+        XCTAssertNotEqual(vod1.hlsData, vod2.hlsData)
+        XCTAssertEqual(vod2.tags.count, 15)
+    }
+
+    func testEventVariantUpdateFailDueToNonMatchingUrls() {
+        
+        // get an initial playlist
+        var event1 = parsePlaylist(inString: eventHLS1)
+        event1.url = testURL1
+        
+        XCTAssertEqual(event1.tags.count, 15)
+        XCTAssertEqual(event1.url, testURL1)
+        
+        // create a special parser that will always do an update on event style variants
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 0,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 60 * 60))
+        
+        let event2 = try! parser.update(eventVariantPlaylist: event1,
+                                        withPlaylistData: eventHLS2.data(using: .utf8)!,
+                                        atUrl: testURL2)
+        
+        XCTAssertNotEqual(event1.hlsData, event2.hlsData)
+        XCTAssertEqual(event2.tags.count, 19)
+        XCTAssertEqual(event2.url, testURL2)
+        XCTAssertNotEqual(event2.url, testURL1)
+    }
+
+    func testEventVariantUpdateFailDueToMissingFragmentInfo() {
+        
+        // this test is just to exercise the "cannot find the last fragment" error condition handling
+        // in the real world we'd never expect a playlist like this
+        
+        // get an initial playlist
+        var event1 = parsePlaylist(inString: """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:EVENT
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+""")
+        event1.url = testURL1
+        
+        XCTAssertEqual(event1.tags.count, 3)
+        
+        // create a special parser that will always do an update on event style variants
+        let parser = HLSParser(updateEventPlaylistParams: UpdateEventPlaylistParams(minimalBytesToTriggerUpdate: 0,
+                                                                                    maximumAmountOfTimeBetweenUpdatesToTrigger: 60 * 60))
+        
+        let event2 = try! parser.update(eventVariantPlaylist: event1,
+                                        withPlaylistData: eventHLS2.data(using: .utf8)!,
+                                        atUrl: testURL1)
+        
+        XCTAssertNotEqual(event1.hlsData, event2.hlsData)
+        XCTAssertEqual(event2.tags.count, 19)
+    }
+}
+
+let eventHLS1 = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:EVENT
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:2.96130,
+fileSequence0.ts
+#EXTINF:2.96130,
+fileSequence1.ts
+#EXTINF:2.96129,
+fileSequence2.ts
+#EXTINF:2.96129,
+fileSequence3.ts
+#EXTINF:2.96130,
+fileSequence4.ts
+#EXTINF:2.96130,
+fileSequence5.ts
+"""
+
+let eventHLS2 = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:EVENT
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:2.96130,
+fileSequence0.ts
+#EXTINF:2.96130,
+fileSequence1.ts
+#EXTINF:2.96129,
+fileSequence2.ts
+#EXTINF:2.96129,
+fileSequence3.ts
+#EXTINF:2.96130,
+fileSequence4.ts
+#EXTINF:2.96130,
+fileSequence5.ts
+#EXTINF:2.96129,
+fileSequence6.ts
+#EXTINF:2.96129,
+fileSequence7.ts
+"""
+
+let eventHLS3 = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:EVENT
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:2.96130,
+fileSequence0.ts
+#EXTINF:2.96130,
+fileSequence1.ts
+#EXTINF:2.96129,
+fileSequence2.ts
+#EXTINF:2.96129,
+fileSequence3.ts
+#EXTINF:2.96130,
+fileSequence4.ts
+#EXTINF:2.96130,
+fileSequence5.ts
+#EXTINF:2.96129,
+fileSequence6.ts
+#EXTINF:2.96129,
+fileSequence7.ts
+#EXT-X-KEY:METHOD=AES-128,URI=\"https://not.a.server.nowhere/key.php?r=52\",IV=0x9c7db8778570d05c3177c349fd9236aa/
+#EXTINF:2.96130,
+fileSequence8.ts
+#EXT-X-DISCONTINUITY
+#EXTINF:2.96130,
+fileSequence9.ts
+#EXTINF:2.96129,
+fileSequence10.ts
+"""
+
+let vodHLS1 = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:2.96130,
+fileSequence0.ts
+#EXTINF:2.96130,
+fileSequence1.ts
+#EXTINF:2.96129,
+fileSequence2.ts
+#EXTINF:2.96129,
+fileSequence3.ts
+"""
+
+let vodHLS2 = """
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:2.96130,
+fileSequence0.ts
+#EXTINF:2.96130,
+fileSequence1.ts
+#EXTINF:2.96129,
+fileSequence2.ts
+#EXTINF:2.96129,
+fileSequence3.ts
+#EXTINF:2.96130,
+fileSequence4.ts
+#EXTINF:2.96130,
+fileSequence5.ts
+"""

--- a/mambaTests/Rapid Parsing Tests/ParseArrayTests.m
+++ b/mambaTests/Rapid Parsing Tests/ParseArrayTests.m
@@ -101,10 +101,11 @@ static const NSInteger foundError = 7;
     self.endData = endComment;
 }
 
-- (void)newURLWithStart:(UInt64)startURL end:(UInt64)endURL {
+- (BOOL)newURLWithStart:(UInt64)startURL end:(UInt64)endURL {
     self.hit = newURL;
     self.startData = startURL;
     self.endData = endURL;
+    return YES;
 }
 
 - (void)parseComplete {
@@ -133,7 +134,7 @@ static const int64_t colonposition = 90;
     uint8_t newState = 0;
     MockHLSRapidParser *mockParser = [MockHLSRapidParser new];
     
-    for(uint8_t state = Scanning; state < ErrorEarlyExit; state++) {
+    for(uint8_t state = Scanning; state < numberOfScanningParseStates; state++) {
         for(unsigned char c = 0; c < 255; c++) {
             
             initializeLineState(&lineState);


### PR DESCRIPTION

### Description

This PR addresses issues #32 and #20.

#32 is adding support for "updates" in Event style variant playlists. Look in that issue for more details on why this is a useful feature.

#20 is fixing a bug where, if the caller deletes a `HLSParser` in the middle of a parse, the callback for a finish parse never happens.

### Change Notes

* Added a facility in the C `HLSRapidParser` level of mamba to be able to exit early out of parsing HLS if the client of the parser requests. This is only done in response to a new "Location" style tag. This is done because the strategy is to look for the last "Location" URL from the old playlist in the new playlist, as that tag should be unique.
* Add a couple of `update(eventVariantPlaylist:...)` methods in `HLSParser` to support updating event variant playlists (one method is synchronous and one is asynchronous). These new methods will do sanity checks to see if it's possible/allowed to do an "update" rather than a parse from scratch.
* `HLSParser` can be configured with a `UpdateEventPlaylistParams` struct (there's one provided by default with default values). This can be used to change (1) the minimum size required for a update (it's not really a win to update small playlists and in fact can be slower) (2) the maximum time between updates (i.e. if we have a copy of a variant from 10 minutes ago, there are so many new fragments between now and then that it's likely to be faster to just parse from scratch). This is here mostly to configure for unit tests, but users can use it to tune results if they are unhappy with defaults.
* To fix #20, the `HLSParseWorker` how keeps a strong ref to the parent `HLSParser` while the parse is happening. The strong ref is dropped when the parse is complete to avoid retain cycles.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
