### PR TITLE
Add support for Pantos tag EXT-X-BITRATE.

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		1D9D9E9E1EAFC0E300CC7274 /* hls_master_playlist.m3u8 in Resources */ = {isa = PBXBuildFile; fileRef = 1D28F3431EAA9E500010320B /* hls_master_playlist.m3u8 */; };
 		1D9D9E9F1EAFC0E600CC7274 /* hls_variant_playlist.m3u8 in Resources */ = {isa = PBXBuildFile; fileRef = 1D28F3441EAA9E500010320B /* hls_variant_playlist.m3u8 */; };
 		1D9D9EA01EAFC0F700CC7274 /* HLSStringRefExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883290551EA172170064588B /* HLSStringRefExtensionTests.swift */; };
+		3D933C1A2193367C0029069F /* EXT-X-BITRATETagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D933C192193367C0029069F /* EXT-X-BITRATETagParserTests.swift */; };
+		3D933C1B219336970029069F /* EXT-X-BITRATETagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D933C192193367C0029069F /* EXT-X-BITRATETagParserTests.swift */; };
+		3D933C1C219336970029069F /* EXT-X-BITRATETagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D933C192193367C0029069F /* EXT-X-BITRATETagParserTests.swift */; };
 		4367C3731EAE83C000685945 /* HLSPlaylistStructureMasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4367C3721EAE83C000685945 /* HLSPlaylistStructureMasterTests.swift */; };
 		43DE4EFB1E564DA300EEE800 /* EXT_X_STARTTimeOffsetValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DE4EFA1E564DA300EEE800 /* EXT_X_STARTTimeOffsetValidator.swift */; };
 		43DE4EFD1E564DBE00EEE800 /* EXT_X_MEDIARenditionINSTREAMIDValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DE4EFC1E564DBE00EEE800 /* EXT_X_MEDIARenditionINSTREAMIDValidator.swift */; };
@@ -598,6 +601,7 @@
 		1D28F3421EAA9E500010320B /* hls_master_playlist_sap.m3u8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = hls_master_playlist_sap.m3u8; sourceTree = "<group>"; };
 		1D28F3431EAA9E500010320B /* hls_master_playlist.m3u8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = hls_master_playlist.m3u8; sourceTree = "<group>"; };
 		1D28F3441EAA9E500010320B /* hls_variant_playlist.m3u8 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = hls_variant_playlist.m3u8; sourceTree = "<group>"; };
+		3D933C192193367C0029069F /* EXT-X-BITRATETagParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EXT-X-BITRATETagParserTests.swift"; sourceTree = "<group>"; };
 		4367C3721EAE83C000685945 /* HLSPlaylistStructureMasterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HLSPlaylistStructureMasterTests.swift; sourceTree = "<group>"; };
 		43DE4EFA1E564DA300EEE800 /* EXT_X_STARTTimeOffsetValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = EXT_X_STARTTimeOffsetValidator.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		43DE4EFC1E564DBE00EEE800 /* EXT_X_MEDIARenditionINSTREAMIDValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EXT_X_MEDIARenditionINSTREAMIDValidator.swift; sourceTree = "<group>"; };
@@ -1063,6 +1067,7 @@
 		EC3B57F41D36CCE7006656C3 /* Tag Parser Tests */ = {
 			isa = PBXGroup;
 			children = (
+				3D933C192193367C0029069F /* EXT-X-BITRATETagParserTests.swift */,
 				EC7492671DD29EC800AF4E20 /* EXT_X_ALLOW_CACHETagParserTests.swift */,
 				EC7492681DD29EC800AF4E20 /* EXT_X_I_FRAME_STREAM_INFTagParserTests.swift */,
 				EC7492691DD29EC800AF4E20 /* EXT_X_KEYTagParserTests.swift */,
@@ -1818,6 +1823,7 @@
 				ECFBD9031E5CCAAF00379FC2 /* XCTestCase+mamba.swift in Sources */,
 				EC7492A11DD29F4600AF4E20 /* ThirdPartyTagListSupportTests.swift in Sources */,
 				EC073F571FE0572400689228 /* HLSTagCriterionTests.swift in Sources */,
+				3D933C1A2193367C0029069F /* EXT-X-BITRATETagParserTests.swift in Sources */,
 				EC37A8D71E9C16C7005E8342 /* HLSPlaylistStructureAndEditingTests.swift in Sources */,
 				EC073F5D1FE0840000689228 /* OutputStreamExtensionTests.swift in Sources */,
 				ECC410671EA1527700B4E3C8 /* HLSTagGroupTests.swift in Sources */,
@@ -1978,6 +1984,7 @@
 				EC7492851DD29EC800AF4E20 /* StringDictionaryParserTests.swift in Sources */,
 				EC7492AE1DD29F7000AF4E20 /* URL+hlsplaylistTests.swift in Sources */,
 				EC073F581FE0572400689228 /* HLSTagCriterionTests.swift in Sources */,
+				3D933C1C219336970029069F /* EXT-X-BITRATETagParserTests.swift in Sources */,
 				ECFBD9041E5CCAAF00379FC2 /* XCTestCase+mamba.swift in Sources */,
 				EC073F5E1FE0840000689228 /* OutputStreamExtensionTests.swift in Sources */,
 				EC37A8D81E9C16C7005E8342 /* HLSPlaylistStructureAndEditingTests.swift in Sources */,
@@ -2138,6 +2145,7 @@
 				ECE253EB209A50A100D388CE /* ParseArrayTests.m in Sources */,
 				ECE253DB209A509900D388CE /* HLSPlaylistTimelineAndSequencingTests.swift in Sources */,
 				ECE253E5209A509900D388CE /* HLSTagWriting.swift in Sources */,
+				3D933C1B219336970029069F /* EXT-X-BITRATETagParserTests.swift in Sources */,
 				ECE253D3209A509000D388CE /* HLSPlaylistMock.swift in Sources */,
 				ECE253F5209A50B500D388CE /* GenericNoDataTagParserTests.swift in Sources */,
 				ECE253D4209A509000D388CE /* HLSTagParserMock.swift in Sources */,

--- a/mamba.xcworkspace/contents.xcworkspacedata
+++ b/mamba.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/jpierc213/Documents/Development/mamba/mambaPlayground.playground">
+      location = "group:mambaPlayground.playground">
    </FileRef>
    <FileRef
       location = "group:mamba.xcodeproj">

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
@@ -67,6 +67,7 @@ public enum PantosTag: String {
     
     // MARK: Variant playlist - Media segment tags
     case EXTINF = "EXTINF"
+    case EXT_X_BITRATE = "EXT_X_BITRATE"
     case EXT_X_BYTERANGE = "EXT-X-BYTERANGE"
     case EXT_X_KEY = "EXT-X-KEY"
     case EXT_X_MAP = "EXT-X-MAP"
@@ -135,6 +136,8 @@ extension PantosTag: HLSTagDescriptor, Equatable {
         case .EXT_X_TARGETDURATION:
             return .wholePlaylist
         
+        case .EXT_X_BITRATE:
+            fallthrough
         case .EXT_X_MAP:
             fallthrough
         case .EXT_X_KEY:
@@ -161,6 +164,8 @@ extension PantosTag: HLSTagDescriptor, Equatable {
         case .EXT_X_ENDLIST:
             return .noValue
             
+        case .EXT_X_BITRATE:
+            fallthrough
         case .EXT_X_BYTERANGE:
             fallthrough
         case .EXT_X_PROGRAM_DATE_TIME:
@@ -247,7 +252,10 @@ extension PantosTag: HLSTagDescriptor, Equatable {
         case .EXT_X_DISCONTINUITY_SEQUENCE:
             return GenericSingleValueTagParser(tag: pantostag,
                                                singleValueIdentifier:PantosValue.discontinuitySequence)
-            
+        case .EXT_X_BITRATE:
+            return GenericSingleValueTagParser(tag: pantostag,
+                                               singleValueIdentifier:PantosValue.bandwidthBPS)
+
         // GenericDictionaryTagParser
             
         case .EXT_X_STREAM_INF:
@@ -307,7 +315,9 @@ extension PantosTag: HLSTagDescriptor, Equatable {
             return GenericSingleTagWriter(singleTagValueIdentifier: PantosValue.byterange)
         case .EXT_X_DISCONTINUITY_SEQUENCE:
             return GenericSingleTagWriter(singleTagValueIdentifier: PantosValue.discontinuitySequence)
-            
+        case .EXT_X_BITRATE:
+            return GenericSingleTagWriter(singleTagValueIdentifier: PantosValue.bandwidthBPS)
+
         // GenericDictionaryTagWriter
             
         case .EXT_X_STREAM_INF:
@@ -371,7 +381,10 @@ extension PantosTag: HLSTagDescriptor, Equatable {
         case .EXT_X_DISCONTINUITY_SEQUENCE:
             return GenericSingleTagValidator<Int>(tag: pantostag,
                                                   singleValueIdentifier:PantosValue.discontinuitySequence)
-            
+        case .EXT_X_BITRATE:
+            return GenericSingleTagValidator<Double>(tag: pantostag,
+                                                  singleValueIdentifier:PantosValue.bandwidthBPS)
+
         case .EXT_X_STREAM_INF:
             return GenericDictionaryTagValidator(tag: pantostag, dictionaryValueIdentifiers: [
                 HLSDictionaryTagValueIdentifierImpl(valueId: PantosValue.bandwidthBPS, optional: false, expectedType: Int.self),
@@ -481,8 +494,9 @@ extension PantosTag: HLSTagDescriptor, Equatable {
                        PantosTag.EXT_X_DISCONTINUITY_SEQUENCE,
                        PantosTag.EXT_X_INDEPENDENT_SEGMENTS,
                        PantosTag.EXT_X_START,
-                       PantosTag.EXT_X_DISCONTINUITY]
-        
+                       PantosTag.EXT_X_DISCONTINUITY,
+                       PantosTag.EXT_X_BITRATE]
+
         var dictionary = [UInt: [(descriptor: PantosTag, string: HLSStringRef)]]()
         
         for tag in tagList {

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
@@ -67,7 +67,7 @@ public enum PantosTag: String {
     
     // MARK: Variant playlist - Media segment tags
     case EXTINF = "EXTINF"
-    case EXT_X_BITRATE = "EXT_X_BITRATE"
+    case EXT_X_BITRATE = "EXT-X-BITRATE"
     case EXT_X_BYTERANGE = "EXT-X-BYTERANGE"
     case EXT_X_KEY = "EXT-X-KEY"
     case EXT_X_MAP = "EXT-X-MAP"

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTag.swift
@@ -383,7 +383,7 @@ extension PantosTag: HLSTagDescriptor, Equatable {
                                                   singleValueIdentifier:PantosValue.discontinuitySequence)
         case .EXT_X_BITRATE:
             return GenericSingleTagValidator<Double>(tag: pantostag,
-                                                  singleValueIdentifier:PantosValue.bandwidthBPS)
+                                                     singleValueIdentifier:PantosValue.bandwidthBPS)
 
         case .EXT_X_STREAM_INF:
             return GenericDictionaryTagValidator(tag: pantostag, dictionaryValueIdentifiers: [

--- a/mambaTests/Fixtures/hls_singleMediaFile.txt
+++ b/mambaTests/Fixtures/hls_singleMediaFile.txt
@@ -1,5 +1,6 @@
 #EXTM3U
 #EXT-X-TARGETDURATION:10
+#EXT-X-BITRATE:3000000
 #EXTINF:5220,
 http://media.example.com/entire.ts
 #EXT-X-ENDLIST

--- a/mambaTests/HLSParserTest.swift
+++ b/mambaTests/HLSParserTest.swift
@@ -27,23 +27,25 @@ class HLSParserTest: XCTestCase {
         
         let playlist = parsePlaylist(inString: hlsString)
         
-        XCTAssert(playlist.tags.count == 4, "Misparsed the HLS")
+        XCTAssert(playlist.tags.count == 5, "Misparsed the HLS")
         
         XCTAssert(playlist.tags[0].tagDescriptor == PantosTag.EXT_X_TARGETDURATION, "Tag did not parse properly")
-        XCTAssert(playlist.tags[1].tagDescriptor == PantosTag.EXTINF, "Tag did not parse properly")
-        XCTAssert(playlist.tags[2].tagDescriptor == PantosTag.Location, "Tag did not parse properly")
-        XCTAssert(playlist.tags[3].tagDescriptor == PantosTag.EXT_X_ENDLIST, "Tag did not parse properly")
+        XCTAssert(playlist.tags[1].tagDescriptor.toString() == PantosTag.EXT_X_BITRATE.rawValue, "Tag did not parse properly")
+        XCTAssert(playlist.tags[2].tagDescriptor == PantosTag.EXTINF, "Tag did not parse properly")
+        XCTAssert(playlist.tags[3].tagDescriptor == PantosTag.Location, "Tag did not parse properly")
+        XCTAssert(playlist.tags[4].tagDescriptor == PantosTag.EXT_X_ENDLIST, "Tag did not parse properly")
         
         XCTAssert(playlist.tags[0].tagName! == "#\(PantosTag.EXT_X_TARGETDURATION.toString())", "Tag did not parse properly")
-        XCTAssert(playlist.tags[1].tagName! == "#\(PantosTag.EXTINF.toString())", "Tag did not parse properly")
-        XCTAssert(playlist.tags[2].tagName == nil, "Tag did not parse properly") // locations do not have tag names
-        XCTAssert(playlist.tags[3].tagName! == "#\(PantosTag.EXT_X_ENDLIST.toString())", "Tag did not parse properly")
+        XCTAssert(playlist.tags[1].tagName! == "#\(PantosTag.EXT_X_BITRATE.toString())", "Tag did not parse properly")
+        XCTAssert(playlist.tags[2].tagName! == "#\(PantosTag.EXTINF.toString())", "Tag did not parse properly")
+        XCTAssert(playlist.tags[3].tagName == nil, "Tag did not parse properly") // locations do not have tag names
+        XCTAssert(playlist.tags[4].tagName! == "#\(PantosTag.EXT_X_ENDLIST.toString())", "Tag did not parse properly")
         
         XCTAssert(playlist.tags[0].value(forValueIdentifier: PantosValue.targetDurationSeconds) == 10, "Tag did not parse properly")
         
-        XCTAssert(playlist.tags[1].duration.seconds == 5220.0, "Tag did not parse properly")
+        XCTAssert(playlist.tags[2].duration.seconds == 5220.0, "Tag did not parse properly")
         
-        XCTAssert(playlist.tags[2].tagData == "http://media.example.com/entire.ts", "Tag did not parse properly")
+        XCTAssert(playlist.tags[3].tagData == "http://media.example.com/entire.ts", "Tag did not parse properly")
         
         let testNilValue: String? = playlist.tags[3].value(forValueIdentifier: PantosValue.targetDurationSeconds)
         XCTAssert(testNilValue == nil, "Tag did not parse properly")

--- a/mambaTests/PantosTagTests.swift
+++ b/mambaTests/PantosTagTests.swift
@@ -41,7 +41,8 @@ class PantosTagTests: XCTestCase {
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_MEDIA)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_I_FRAME_STREAM_INF)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_ENDLIST)
-        
+        runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_BITRATE)
+
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_INDEPENDENT_SEGMENTS)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_START)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_TARGETDURATION)
@@ -93,6 +94,8 @@ class PantosTagTests: XCTestCase {
         case .EXT_X_TARGETDURATION:
             fallthrough
         case .EXT_X_MAP:
+            fallthrough
+        case .EXT_X_BITRATE:
             fallthrough
         case .EXTINF:
             let stringRef = HLSStringRef(string: "#\(descriptor.toString())")

--- a/mambaTests/Tag Parser Tests/EXT-X-BITRATETagParserTests.swift
+++ b/mambaTests/Tag Parser Tests/EXT-X-BITRATETagParserTests.swift
@@ -23,14 +23,14 @@ import XCTest
 
 class EXT_X_BITRATETagParserTests: XCTestCase {
     
-    func testFullTag() {
+    func testValidTag() {
         let parser = PantosTag.parser(forTag: PantosTag.EXT_X_BITRATE)
         
         do {
             let valueDictionary = try parser!.parseTag(fromTagString: "3492800")
             
-            XCTAssert(valueDictionary[PantosValue.bandwidthBPS.rawValue]?.value == "3492800", "Tag did not parse properly")
-            XCTAssert(valueDictionary[PantosValue.bandwidthBPS.rawValue]?.quoteEscaped == false, "Tag did not parse properly")
+            XCTAssertEqual(valueDictionary[PantosValue.bandwidthBPS.rawValue]?.value, "3492800", "Expected \"3492800\"")
+            XCTAssertEqual(valueDictionary[PantosValue.bandwidthBPS.rawValue]?.quoteEscaped, false, "Expected \"false\"")
         }
         catch {
             XCTAssert(false, "Parser should not throw")

--- a/mambaTests/Tag Parser Tests/EXT-X-BITRATETagParserTests.swift
+++ b/mambaTests/Tag Parser Tests/EXT-X-BITRATETagParserTests.swift
@@ -1,0 +1,40 @@
+//
+//  EXT-X-BITRATETagParserTests.swift
+//  mambaTests
+//
+//  Created by Youngkin, Richard on 11/7/18.
+//  Copyright © 2018 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import XCTest
+
+@testable import mamba
+
+class EXT_X_BITRATETagParserTests: XCTestCase {
+    
+    func testFullTag() {
+        let parser = PantosTag.parser(forTag: PantosTag.EXT_X_BITRATE)
+        
+        do {
+            let valueDictionary = try parser!.parseTag(fromTagString: "3492800")
+            
+            XCTAssert(valueDictionary[PantosValue.bandwidthBPS.rawValue]?.value == "3492800", "Tag did not parse properly")
+            XCTAssert(valueDictionary[PantosValue.bandwidthBPS.rawValue]?.quoteEscaped == false, "Tag did not parse properly")
+        }
+        catch {
+            XCTAssert(false, "Parser should not throw")
+        }
+    }
+    
+}


### PR DESCRIPTION
There was also a minor change to mamba.xcworkspace/contents.xcworkspacedata
to remove a hardcoded path to the mambaPlayground.

---

### Description

This PR implements support for a new Pantos tag, EXT_X_BITRATE (see the [HLS Spec](https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-03#page-23) for details).

### Change Notes

* Added new test file, "mambaTests/Tag Parser Tests"/EXT-X-BITRATETagParserTests.swift.
* Extended  mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/PantosTags.swift to include the new tag.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

