### PR TITLE
updated to swift 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ _Mamba Project Goals:_
 
 ## Requires
 
-* XCode 9+
-* Swift 3+ (written in Swift 4)
+* XCode 10+
+* Swift 3+ (written in Swift 4.2)
 * iOS 9+ _or_ tvOS 10+ _or_ macOS 10.13+
 
 ## Usage

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -1552,6 +1552,7 @@
 					};
 					EC1CCCDE209A2AF8006B59FF = {
 						CreatedOnToolsVersion = 9.3;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -2217,7 +2218,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2241,7 +2242,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2262,7 +2263,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "mambaTests/mambaTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2281,7 +2282,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "mambaTests/mambaTests-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2308,7 +2309,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -2335,7 +2336,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -2359,7 +2360,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "mambaTests/mambaTVOSTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -2380,7 +2381,7 @@
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "mambaTests/mambaTVOSTests-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -2413,7 +2414,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2444,7 +2445,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2468,7 +2469,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2491,7 +2492,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba.mambaMacOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/mambaSharedFramework/HLS Models/HLSTag.swift
+++ b/mambaSharedFramework/HLS Models/HLSTag.swift
@@ -104,7 +104,7 @@ public struct HLSTag: CustomDebugStringConvertible {
                 tagData: HLSStringRef,
                 tagName: HLSStringRef,
                 parsedValues: HLSTagDictionary? = nil,
-                duration: CMTime = kCMTimeInvalid) {
+                duration: CMTime = CMTime.invalid) {
         
         self.tagDescriptor = tagDescriptor
         self.tagData = tagData
@@ -127,7 +127,7 @@ public struct HLSTag: CustomDebugStringConvertible {
         self.tagDescriptor = tagDescriptor
         self.tagData = tagData
         self.tagName = nil
-        self.duration = kCMTimeInvalid
+        self.duration = CMTime.invalid
     }
     
     /**
@@ -155,7 +155,7 @@ public struct HLSTag: CustomDebugStringConvertible {
         }
         self.parsedValues = parsedValues
         self.isDirty = parsedValues != nil
-        self.duration = kCMTimeInvalid
+        self.duration = CMTime.invalid
     }
     
     /**

--- a/mambaSharedFramework/HLS Models/Playlist Structure/HLSPlaylistStructure.swift
+++ b/mambaSharedFramework/HLS Models/Playlist Structure/HLSPlaylistStructure.swift
@@ -368,8 +368,8 @@ fileprivate struct HLSPlaylistStructureConstructor {
         var mediaSegmentGroups = [MediaSegmentTagGroup]()
         
         var currentMediaSequence: MediaSequence = defaultMediaSequence
-        var lastRecordedTime: CMTime = kCMTimeInvalid
-        var currentSegmentDuration: CMTime = kCMTimeInvalid
+        var lastRecordedTime: CMTime = CMTime.invalid
+        var currentSegmentDuration: CMTime = CMTime.invalid
         var discontinuity = false
         let tagDescriptor = self.tagDescriptor(forTags: tags)
         
@@ -466,7 +466,7 @@ fileprivate struct HLSPlaylistStructureConstructor {
                 mediaGroupBeginIndex = tagIndex + 1
                 
                 // reset for next media group
-                currentSegmentDuration = kCMTimeInvalid
+                currentSegmentDuration = CMTime.invalid
                 discontinuity = false
             }
         }

--- a/mambaSharedFramework/HLS Models/Playlist Structure/HLSPlaylistStructureInterface.swift
+++ b/mambaSharedFramework/HLS Models/Playlist Structure/HLSPlaylistStructureInterface.swift
@@ -67,7 +67,7 @@ extension HLSPlaylistStructureInterface {
      The CMTime will be kCMTimeInvalid if we cannot determine a start time.
      */
     public var startTime: CMTime {
-        guard let timeRange = mediaSegmentGroups.first?.timeRange else { return kCMTimeInvalid }
+        guard let timeRange = mediaSegmentGroups.first?.timeRange else { return CMTime.invalid }
         return timeRange.start
     }
     
@@ -77,7 +77,7 @@ extension HLSPlaylistStructureInterface {
      The CMTime will be kCMTimeInvalid if we cannot determine a end time.
      */
     public var endTime: CMTime {
-        guard let timeRange = mediaSegmentGroups.last?.timeRange else { return kCMTimeInvalid }
+        guard let timeRange = mediaSegmentGroups.last?.timeRange else { return CMTime.invalid }
         return timeRange.end
     }
     
@@ -88,7 +88,7 @@ extension HLSPlaylistStructureInterface {
      */
     public var duration: CMTime {
         guard startTime.isNumeric && endTime.isNumeric else {
-            return kCMTimeInvalid
+            return CMTime.invalid
         }
         return CMTimeSubtract(endTime, startTime)
     }

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXTINFValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXTINFValidator.swift
@@ -24,7 +24,7 @@ class EXTINFValidator: HLSTagValidator {
     
     public func validate(tag: HLSTag) -> [HLSValidationIssue]? {
         
-        if !(tag.duration.isNumeric && tag.duration > kCMTimeZero) {
+        if !(tag.duration.isNumeric && tag.duration > CMTime.zero) {
             return [HLSValidationIssue(description: IssueDescription.EXTINFTagsRequireADurationValidator, severity: IssueSeverity.error)]
         }
         return nil

--- a/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXT_X_STARTTimeOffsetValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic HLS Playlist Parsing/Pantos-Generic Tag Validators/EXT_X_STARTTimeOffsetValidator.swift
@@ -46,7 +46,7 @@ class  EXT_X_STARTTimeOffsetValidator: HLSPlaylistValidator {
             let targetDuration: CMTime = targetDurationTag?.value(forValueIdentifier: PantosValue.targetDurationSeconds)
             else { return nil }
         
-        let latestAllowedStartTime = playlist.endTime - CMTimeMultiply(targetDuration, 3)
+        let latestAllowedStartTime = playlist.endTime - CMTimeMultiply(targetDuration, multiplier: 3)
         
         if (startTimeOffSet > playlist.endTime) || (!endListExist && startTimeOffSet > latestAllowedStartTime) {
             return [HLSValidationIssue(description: IssueDescription.EXT_X_STARTTimeOffsetValidator, severity: IssueSeverity.error)]

--- a/mambaTests/HLSPlaylistInterfaceTests.swift
+++ b/mambaTests/HLSPlaylistInterfaceTests.swift
@@ -100,11 +100,11 @@ class HLSPlaylistInterfaceTests: XCTestCase {
         XCTAssertFalse(playlistMaster.canQueryTimeline())
         XCTAssertTrue(playlistVariant.canQueryTimeline())
         
-        XCTAssertNil(playlistMaster.mediaSequence(forTime: kCMTimeZero))
+        XCTAssertNil(playlistMaster.mediaSequence(forTime: CMTime.zero))
         XCTAssertNil(playlistMaster.mediaSequence(forTagIndex: 0))
         XCTAssertNil(playlistMaster.timeRange(forTagIndex: 0))
         XCTAssertNil(playlistMaster.timeRange(forMediaSequence: 0))
-        XCTAssertNil(playlistMaster.tagIndexes(forTime: kCMTimeZero))
+        XCTAssertNil(playlistMaster.tagIndexes(forTime: CMTime.zero))
         XCTAssertNotNil(playlistMaster.tagIndexes(forMediaSequence: 0))
     }
     


### PR DESCRIPTION
### Description

This PR adds support to Swift 4.2

### Change Notes

Swift 4.2 changes to deprecated names ex: kCMTimeInvalid -> CMTime.invalid

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [NA] I have written useful documentation for all public code.
- [NA] I have written unit tests for this new feature.

