### PR TITLE
Adding multiple codec string support

### DIFF
--- a/mambaSharedFramework/HLSValueTypes.swift
+++ b/mambaSharedFramework/HLSValueTypes.swift
@@ -194,8 +194,8 @@ public struct HLSClosedCaptions: FailableStringLiteralConvertible {
 /// We are currently not parsing these values further
 public struct HLSCodec: Equatable {
     
-    static let audioPrefix = "mp4a"
-    static let videoPrefix = "avc"
+    static let audioPrefixes: [String] = ["mp4a", "mp3", "ec-3", "ac-3"]
+    static let videoPrefixes: [String] = ["avc", "mp4v", "svc", "mvc", "sevc", "s263", "hvc", "vp9"]
     public let codecDescriptor: String
     
     init(codecDescriptor: String) {
@@ -236,15 +236,15 @@ public struct HLSCodecArray: Equatable, FailableStringLiteralConvertible {
     }
 
     public func containsAudioOnly() -> Bool {
-        return self.codecs.filter({ $0.codecDescriptor.hasPrefix(HLSCodec.audioPrefix)}).count == self.codecs.count
+        return containsAudio() && !containsVideo()
     }
 
     public func containsAudio() -> Bool {
-        return self.contains(codecTypeTest: { return $0.codecDescriptor.hasPrefix(HLSCodec.audioPrefix) })
+        return HLSCodec.audioPrefixes.filter( { audioPrefix in return self.codecs.filter( { $0.codecDescriptor.hasPrefix(audioPrefix) } ).count > 0 } ).count > 0
     }
    
     public func containsVideo() -> Bool {
-        return self.contains(codecTypeTest: { return $0.codecDescriptor.hasPrefix(HLSCodec.videoPrefix) })
+        return HLSCodec.videoPrefixes.filter( { videoPrefix in return self.codecs.filter( { $0.codecDescriptor.hasPrefix(videoPrefix) } ).count > 0 } ).count > 0
     }
     
     public func containsAudioVideo() -> Bool {

--- a/mambaTests/Util Tests/Value Types/HLSCodecArrayTests.swift
+++ b/mambaTests/Util Tests/Value Types/HLSCodecArrayTests.swift
@@ -45,6 +45,48 @@ class HLSCodecArrayTests: XCTestCase {
     func testHLSCodecArrayWithSpaces() {
         let _ = runTestsOn(codecString: "avc1.4d401f, mp4a.40.5")
     }
+
+    func testAudioVideoCodecDetection() {
+        // audio + video
+        runAVTest(onCodecString: "avc1.4d401f,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        // audio only
+        runAVTest(onCodecString: "mp4a.40.5", expectingAudioOnly: true, expectingVideo: false, expectingAudio: true)
+        // video only
+        runAVTest(onCodecString: "avc1.4d401f", expectingAudioOnly: false, expectingVideo: true, expectingAudio: false)
+        
+        // testing different audio codec strings
+        runAVTest(onCodecString: "avc1.4d401f,ec-3", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "avc1.4d401f,ac-3", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "avc1.4d401f,mp3", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+
+        // testing different video codec strings
+        runAVTest(onCodecString: "mp4v.20.9,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "svc,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "mvc1.800030,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "sevc,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "s263,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "hvc1.1.c.L120.90,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "vp9,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        
+        // testing two video codecs
+        runAVTest(onCodecString: "avc1.4d401f,hvc1.1.c.L120.90,mp4a.40.5", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "avc1.4d401f,hvc1.1.c.L120.90", expectingAudioOnly: false, expectingVideo: true, expectingAudio: false)
+        // testing two audio codecs
+        runAVTest(onCodecString: "avc1.4d401f,mp4a.40.5,ec-3", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "mp4a.40.5,ec-3", expectingAudioOnly: true, expectingVideo: false, expectingAudio: true)
+    }
+    
+    func runAVTest(onCodecString codecString: String,
+                   expectingAudioOnly: Bool,
+                   expectingVideo: Bool,
+                   expectingAudio: Bool) {
+        
+        let codecs = HLSCodecArray(string: codecString)
+        
+        XCTAssert(codecs?.containsAudioOnly() == expectingAudioOnly, "Expecting a audio only value of \(expectingAudioOnly) for codecs: \"\(codecString)\"")
+        XCTAssert(codecs?.containsVideo() == expectingVideo, "Expecting a video value of \(expectingVideo) for codecs: \"\(codecString)\"")
+        XCTAssert(codecs?.containsAudio() == expectingAudio, "Expecting a audio value of \(expectingAudio) for codecs: \"\(codecString)\"")
+    }
     
     func runTestsOn(codecString: String) -> HLSCodecArray {
         let codecs1 = HLSCodecArray(string: codecString)

--- a/mambaTests/Util Tests/Value Types/HLSCodecArrayTests.swift
+++ b/mambaTests/Util Tests/Value Types/HLSCodecArrayTests.swift
@@ -74,6 +74,10 @@ class HLSCodecArrayTests: XCTestCase {
         // testing two audio codecs
         runAVTest(onCodecString: "avc1.4d401f,mp4a.40.5,ec-3", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
         runAVTest(onCodecString: "mp4a.40.5,ec-3", expectingAudioOnly: true, expectingVideo: false, expectingAudio: true)
+        
+        // testing unknown codecs
+        runAVTest(onCodecString: "avc1.4d401f,mp4a.40.5,unknown", expectingAudioOnly: false, expectingVideo: true, expectingAudio: true)
+        runAVTest(onCodecString: "unknown", expectingAudioOnly: false, expectingVideo: false, expectingAudio: false)
     }
     
     func runAVTest(onCodecString codecString: String,


### PR DESCRIPTION

### Description

This PR implements a fix for issue #3 .

### Change Notes

* Added all video and audio codec prefix strings known to us at this time (including the HEVC `hvc`, as well as Dolby Digital formats, as well as a bunch of more obscure codecs).
* Updated `HLSCodecArray` `containsAudio` and `containsVideo` methods to use the new definitions.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
