### PR TITLE
Fixing resolution sorting

### DIFF
--- a/mambaSharedFramework/HLS Utils/Collections/HLSTagArray+RenditionGroups.swift
+++ b/mambaSharedFramework/HLS Utils/Collections/HLSTagArray+RenditionGroups.swift
@@ -98,7 +98,10 @@ public extension Collection where Iterator.Element == HLSTag {
             if let aResolution: HLSResolution = a.resolution(),
                 let bResolution: HLSResolution = b.resolution() {
                 if aResolution < bResolution { return true }
-                if bResolution > aResolution { return false }
+                if aResolution > bResolution { return false }
+            }
+            else if let _ = b.resolution() {
+                return true
             }
             
             if let aBandwidth: Double = a.bandwidth(),

--- a/mambaTests/HLSTagCollectionTests.swift
+++ b/mambaTests/HLSTagCollectionTests.swift
@@ -52,24 +52,24 @@ class HLSTagCollectionTests: XCTestCase {
     }
     
     func testSortedBy() {
-//        let master = parsePlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-//
-//        let tags = master.tags.sortedByResolutionBandwidth().filtered(by: PantosTag.EXT_X_STREAM_INF)
-//        
-//        XCTAssert(tags.count == 8)
-//        
-//        let tag1_bw: Int = tags[1].value(forValueIdentifier: PantosValue.bandwidthBPS)!
-//        let tag3_bw: Int = tags[3].value(forValueIdentifier: PantosValue.bandwidthBPS)!
-//        let tag7_bw: Int = tags[7].value(forValueIdentifier: PantosValue.bandwidthBPS)!
-//        let tag1_res: HLSResolution = tags[1].value(forValueIdentifier: PantosValue.resolution)!
-//        let tag3_res: HLSResolution = tags[3].value(forValueIdentifier: PantosValue.resolution)!
-//        let tag7_res: HLSResolution = tags[7].value(forValueIdentifier: PantosValue.resolution)!
-//        
-//        XCTAssert(tag1_bw < tag3_bw)
-//        XCTAssert(tag1_bw < tag7_bw)
-//        XCTAssert(tag3_bw < tag7_bw)
-//        XCTAssert(tag1_res < tag3_res)
-//        XCTAssert(tag1_res < tag7_res)
-//        XCTAssert(tag3_res < tag7_res)
+        let master = parsePlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
+
+        let tags = master.tags.sortedByResolutionBandwidth().filtered(by: PantosTag.EXT_X_STREAM_INF)
+        
+        XCTAssert(tags.count == 8)
+        
+        let tag1_bw: Int = tags[1].value(forValueIdentifier: PantosValue.bandwidthBPS)!
+        let tag3_bw: Int = tags[3].value(forValueIdentifier: PantosValue.bandwidthBPS)!
+        let tag7_bw: Int = tags[7].value(forValueIdentifier: PantosValue.bandwidthBPS)!
+        let tag1_res: HLSResolution = tags[1].value(forValueIdentifier: PantosValue.resolution)!
+        let tag3_res: HLSResolution = tags[3].value(forValueIdentifier: PantosValue.resolution)!
+        let tag7_res: HLSResolution = tags[7].value(forValueIdentifier: PantosValue.resolution)!
+        
+        XCTAssert(tag1_bw < tag3_bw)
+        XCTAssert(tag1_bw < tag7_bw)
+        XCTAssert(tag3_bw < tag7_bw)
+        XCTAssert(tag1_res < tag3_res)
+        XCTAssert(tag1_res < tag7_res)
+        XCTAssert(tag3_res < tag7_res)
     }
 }


### PR DESCRIPTION
### Description

This PR fixes an issue with sorting by resolution and bandwidth.

### Change Notes

* Fixes resolution sorting.
* Reenables the sorting unit test.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

