### PR TITLE
Adding StaticMemoryStorage, Xcode 10.2 fixes and Resolution Sort fixes from the 1.x branch

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -190,6 +190,15 @@
 		EC1CCD61209A2CF9006B59FF /* HLSValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491B11DD29D5C00AF4E20 /* HLSValueTypes.swift */; };
 		EC1CCD62209A2CF9006B59FF /* HLSWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491B21DD29D5C00AF4E20 /* HLSWriter.swift */; };
 		EC1CCD63209A2CF9006B59FF /* Mamba.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9547871E5CC84700962535 /* Mamba.swift */; };
+		EC318B51226534AF00969E2D /* StaticMemoryStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = EC318B4F226534AF00969E2D /* StaticMemoryStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC318B52226534AF00969E2D /* StaticMemoryStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = EC318B4F226534AF00969E2D /* StaticMemoryStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC318B53226534AF00969E2D /* StaticMemoryStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = EC318B4F226534AF00969E2D /* StaticMemoryStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC318B54226534AF00969E2D /* StaticMemoryStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = EC318B50226534AF00969E2D /* StaticMemoryStorage.m */; };
+		EC318B55226534AF00969E2D /* StaticMemoryStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = EC318B50226534AF00969E2D /* StaticMemoryStorage.m */; };
+		EC318B56226534AF00969E2D /* StaticMemoryStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = EC318B50226534AF00969E2D /* StaticMemoryStorage.m */; };
+		EC318B58226534F400969E2D /* StaticMemoryStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC318B57226534F400969E2D /* StaticMemoryStorageTests.m */; };
+		EC318B59226534F400969E2D /* StaticMemoryStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC318B57226534F400969E2D /* StaticMemoryStorageTests.m */; };
+		EC318B5A226534F400969E2D /* StaticMemoryStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC318B57226534F400969E2D /* StaticMemoryStorageTests.m */; };
 		EC349AC12236BFAC0077432B /* PlaylistCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC349AC02236BFAC0077432B /* PlaylistCore.swift */; };
 		EC349AC22236BFAC0077432B /* PlaylistCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC349AC02236BFAC0077432B /* PlaylistCore.swift */; };
 		EC349AC32236BFAC0077432B /* PlaylistCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC349AC02236BFAC0077432B /* PlaylistCore.swift */; };
@@ -684,6 +693,9 @@
 		EC1CCCDA209A2AF8006B59FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EC1CCCDF209A2AF8006B59FF /* mambaMacOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = mambaMacOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC1CCCE6209A2AF8006B59FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EC318B4F226534AF00969E2D /* StaticMemoryStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticMemoryStorage.h; sourceTree = "<group>"; };
+		EC318B50226534AF00969E2D /* StaticMemoryStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticMemoryStorage.m; sourceTree = "<group>"; };
+		EC318B57226534F400969E2D /* StaticMemoryStorageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticMemoryStorageTests.m; sourceTree = "<group>"; };
 		EC349AC02236BFAC0077432B /* PlaylistCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistCore.swift; sourceTree = "<group>"; };
 		EC349AC42236BFF10077432B /* PlaylistInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistInterface.swift; sourceTree = "<group>"; };
 		EC349AC92236C1520077432B /* PlaylistTypeInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistTypeInterface.swift; sourceTree = "<group>"; };
@@ -933,11 +945,11 @@
 		EC03B62B1E5CC51C00BF1F97 /* HLS Rapid Parser */ = {
 			isa = PBXGroup;
 			children = (
-				F73183721E7872AB00ED8E59 /* HLSStringRef */,
-				EC03B62C1E5CC52C00BF1F97 /* Master Parse Array */,
 				EC03B6411E5CC56B00BF1F97 /* HLSRapidParser.h */,
 				EC03B6421E5CC56B00BF1F97 /* HLSRapidParser.m */,
 				EC03B6431E5CC56B00BF1F97 /* HLSRapidParserCallback.h */,
+				F73183721E7872AB00ED8E59 /* HLSStringRef */,
+				EC03B62C1E5CC52C00BF1F97 /* Master Parse Array */,
 				EC03B6471E5CC56B00BF1F97 /* RapidParser.c */,
 				EC03B6481E5CC56B00BF1F97 /* RapidParser.h */,
 				EC03B6491E5CC56B00BF1F97 /* RapidParserDebug.h */,
@@ -949,6 +961,8 @@
 				EC03B64F1E5CC56B00BF1F97 /* RapidParserState.h */,
 				EC03B6501E5CC56B00BF1F97 /* RapidParserStateHandlers.c */,
 				EC03B6511E5CC56B00BF1F97 /* RapidParserStateHandlers.h */,
+				EC318B4F226534AF00969E2D /* StaticMemoryStorage.h */,
+				EC318B50226534AF00969E2D /* StaticMemoryStorage.m */,
 			);
 			path = "HLS Rapid Parser";
 			sourceTree = "<group>";
@@ -1021,6 +1035,7 @@
 				ECAFFA25223ADF0500A6D5F4 /* PlaylistTimelineAndSequencingTests.swift */,
 				ECFBD9081E5CCBFF00379FC2 /* Rapid Parsing Tests */,
 				ECBEF4F01F7AC58A0051078F /* ReadMeUnitTests.swift */,
+				EC318B57226534F400969E2D /* StaticMemoryStorageTests.m */,
 				ECC410631EA1518E00B4E3C8 /* StructureStateTests.swift */,
 				EC3B57F41D36CCE7006656C3 /* Tag Parser Tests */,
 				0173AB081D5BB304005DE51B /* Tag Validator Tests */,
@@ -1387,6 +1402,7 @@
 				EC03B6621E5CC56B00BF1F97 /* RapidParserDebug.h in Headers */,
 				F700CD371E78A2BE001C9487 /* HLSStringRef_ConcreteNSString.h in Headers */,
 				EC03B6721E5CC56B00BF1F97 /* RapidParserStateHandlers.h in Headers */,
+				EC318B51226534AF00969E2D /* StaticMemoryStorage.h in Headers */,
 				EC03B66C1E5CC56B00BF1F97 /* RapidParserNewTagCallbacks.h in Headers */,
 				EC03B66A1E5CC56B00BF1F97 /* RapidParserLineState.h in Headers */,
 				EC03B66E1E5CC56B00BF1F97 /* RapidParserState.h in Headers */,
@@ -1411,6 +1427,7 @@
 				EC03B6631E5CC56B00BF1F97 /* RapidParserDebug.h in Headers */,
 				F700CD381E78A2BE001C9487 /* HLSStringRef_ConcreteNSString.h in Headers */,
 				EC03B6731E5CC56B00BF1F97 /* RapidParserStateHandlers.h in Headers */,
+				EC318B52226534AF00969E2D /* StaticMemoryStorage.h in Headers */,
 				EC03B66D1E5CC56B00BF1F97 /* RapidParserNewTagCallbacks.h in Headers */,
 				ECFBD9011E5CCA0900379FC2 /* mamba.h in Headers */,
 				EC03B66B1E5CC56B00BF1F97 /* RapidParserLineState.h in Headers */,
@@ -1435,6 +1452,7 @@
 				EC1CCCFA209A2CF9006B59FF /* HLSStringRef.h in Headers */,
 				EC1CCD03209A2CF9006B59FF /* HLSStringRef_ConcreteUnownedBytes.h in Headers */,
 				EC1CCD19209A2CF9006B59FF /* RapidParser.h in Headers */,
+				EC318B53226534AF00969E2D /* StaticMemoryStorage.h in Headers */,
 				EC1CCD07209A2CF9006B59FF /* RapidParserMasterParseArray.h in Headers */,
 				EC1CCD1A209A2CF9006B59FF /* RapidParserDebug.h in Headers */,
 				EC1CCCFD209A2CF9006B59FF /* HLSStringRefFactory.h in Headers */,
@@ -1566,17 +1584,17 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Comcast Corporation.\n//  Licensed under the Apache License, Version 2.0 (the \"License\");\n//  you may not use this file except in compliance with the License.\n//  You may obtain a copy of the License at\n//\n//  http://www.apache.org/licenses/LICENSE-2.0\n//\n//  Unless required by applicable law or agreed to in writing, software\n//  distributed under the License is distributed on an \"AS IS\" BASIS,\n//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n//  See the License for the specific language governing permissions and\n//  limitations under the License.";
 				TargetAttributes = {
 					EC15214E1DD28536006FB265 = {
 						CreatedOnToolsVersion = 8.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Manual;
 					};
 					EC1521561DD28536006FB265 = {
 						CreatedOnToolsVersion = 8.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					EC15216A1DD2856F006FB265 = {
@@ -1605,6 +1623,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -1798,6 +1817,7 @@
 				EC7491591DD29AED00AF4E20 /* HLSTag.swift in Sources */,
 				EC3B01AF1DD4D47900B512E3 /* EXT_X_STREAM_INFRenditionGroupValidator.swift in Sources */,
 				EC3B01CB1DD4D49A00B512E3 /* PlaylistRenditionGroupValidator.swift in Sources */,
+				EC318B54226534AF00969E2D /* StaticMemoryStorage.m in Sources */,
 				EC03B6701E5CC56B00BF1F97 /* RapidParserStateHandlers.c in Sources */,
 				EC7491F81DD29DD300AF4E20 /* GenericDictionaryTagValidator.swift in Sources */,
 				EC7491631DD29B0F00AF4E20 /* CoreMedia+Util.swift in Sources */,
@@ -1861,6 +1881,7 @@
 				EC42A5F51FD9BF0500317EA5 /* IndeterminateBoolTests.swift in Sources */,
 				ECAFFA122239B38300A6D5F4 /* PlaylistInterfaceTests.swift in Sources */,
 				ECFBD9121E5CCC2200379FC2 /* RapidParserTests.swift in Sources */,
+				EC318B58226534F400969E2D /* StaticMemoryStorageTests.m in Sources */,
 				ECCF2DAD1E23F54100D7C48B /* HLSTagTests.swift in Sources */,
 				EC7492801DD29EC800AF4E20 /* GenericSingleValueTagParserTests.swift in Sources */,
 				ECC410641EA1518E00B4E3C8 /* StructureStateTests.swift in Sources */,
@@ -1966,6 +1987,7 @@
 				EC3B01C61DD4D49A00B512E3 /* PlaylistRenditionGroupAudioVideoValidator.swift in Sources */,
 				EC74915A1DD29AED00AF4E20 /* HLSTag.swift in Sources */,
 				EC3B01B01DD4D47900B512E3 /* EXT_X_STREAM_INFRenditionGroupValidator.swift in Sources */,
+				EC318B55226534AF00969E2D /* StaticMemoryStorage.m in Sources */,
 				EC03B6711E5CC56B00BF1F97 /* RapidParserStateHandlers.c in Sources */,
 				EC3B01CC1DD4D49A00B512E3 /* PlaylistRenditionGroupValidator.swift in Sources */,
 				EC7491F91DD29DD300AF4E20 /* GenericDictionaryTagValidator.swift in Sources */,
@@ -2029,6 +2051,7 @@
 				ECFBD9131E5CCC2200379FC2 /* RapidParserTests.swift in Sources */,
 				EC42A5F61FD9BF0500317EA5 /* IndeterminateBoolTests.swift in Sources */,
 				ECAFFA132239B38300A6D5F4 /* PlaylistInterfaceTests.swift in Sources */,
+				EC318B59226534F400969E2D /* StaticMemoryStorageTests.m in Sources */,
 				ECCF2DAE1E23F54100D7C48B /* HLSTagTests.swift in Sources */,
 				EC7492B61DD29F8900AF4E20 /* HLSMediaTypeTests.swift in Sources */,
 				ECC410651EA1518E00B4E3C8 /* StructureStateTests.swift in Sources */,
@@ -2134,6 +2157,7 @@
 				EC1CCD42209A2CF9006B59FF /* EXT_X_STARTTimeOffsetValidator.swift in Sources */,
 				EC1CCD33209A2CF9006B59FF /* GenericDictionaryTagParserHelper.swift in Sources */,
 				EC1CCD3F209A2CF9006B59FF /* EXT_X_MEDIARenditionGroupNAMEValidator.swift in Sources */,
+				EC318B56226534AF00969E2D /* StaticMemoryStorage.m in Sources */,
 				ECDE184A22381E6C008566BB /* URLDataPlaylistExtensions.swift in Sources */,
 				EC1CCD5B209A2CF9006B59FF /* HLSTagDescriptor.swift in Sources */,
 				EC1CCD1C209A2CF9006B59FF /* RapidParserError.m in Sources */,
@@ -2197,6 +2221,7 @@
 				ECE253E9209A509C00D388CE /* PantosTagTests.swift in Sources */,
 				ECE253E4209A509900D388CE /* HLSTagTests.swift in Sources */,
 				ECE25402209A50B500D388CE /* OrderedDictionaryTests.swift in Sources */,
+				EC318B5A226534F400969E2D /* StaticMemoryStorageTests.m in Sources */,
 				ECAFFA142239B38300A6D5F4 /* PlaylistInterfaceTests.swift in Sources */,
 				ECE253E1209A509900D388CE /* HLSTagCollectionTests.swift in Sources */,
 				ECAFFA182239B81100A6D5F4 /* PlaylistStructureAndEditingTests.swift in Sources */,
@@ -2564,6 +2589,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -2624,6 +2650,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mambaSharedFramework/HLS Models/HLSTag.swift
+++ b/mambaSharedFramework/HLS Models/HLSTag.swift
@@ -359,12 +359,15 @@ public func ==(lhs: HLSTag, rhs: HLSTag) -> Bool {
 }
 
 extension HLSTag: Hashable {
-    public var hashValue: Int {
+    public func hash(into hasher: inout Hasher) {
         if let tagName = tagName {
-            return tagData.hashValue ^ tagName.hashValue ^ tagDescriptor.hashValue
+            hasher.combine(tagData)
+            hasher.combine(tagName)
+            tagDescriptor.hash(into: &hasher)
         }
         else {
-            return tagData.hashValue ^ tagDescriptor.hashValue
+            hasher.combine(tagData)
+            tagDescriptor.hash(into: &hasher)
         }
     }
 }

--- a/mambaSharedFramework/HLS Models/Playlist Structure/HLSTagGroup.swift
+++ b/mambaSharedFramework/HLS Models/Playlist Structure/HLSTagGroup.swift
@@ -35,12 +35,12 @@ public protocol TagGroupProtocol {
 public extension TagGroupProtocol {
     
     /// Convenience function to get the start index of the range of this TagGroup
-    public var startIndex: Int {
+    var startIndex: Int {
         return range.lowerBound
     }
     
     /// Convenience function to get the end index of the range of this TagGroup
-    public var endIndex: Int {
+    var endIndex: Int {
         return range.upperBound
     }
 }

--- a/mambaSharedFramework/HLS Models/PlaylistCore.swift
+++ b/mambaSharedFramework/HLS Models/PlaylistCore.swift
@@ -45,9 +45,9 @@ public struct PlaylistCore<PT>: PlaylistInterface, CustomDebugStringConvertible 
     /// custom playlist data
     public var customData: PT.customPlaylistDataType
     
-    /// Many of the tags in this playlist contain `HLSStringRef`s with pointers to memory within a `Data` object.
+    /// Many of the tags in this playlist contain `HLSStringRef`s with pointers to memory within a `StaticMemoryStorage` object.
     /// This reference is here to assure that the data will not go out of scope.
-    public let playlistData: Data
+    public let playlistMemoryStorage: StaticMemoryStorage
     
     /// The registered tag types for this playlist
     public private(set) var registeredTags: RegisteredHLSTags
@@ -57,12 +57,12 @@ public struct PlaylistCore<PT>: PlaylistInterface, CustomDebugStringConvertible 
     /// Initializes PlaylistCore
     public init(tags: [HLSTag],
                 registeredTags: RegisteredHLSTags,
-                playlistData: Data,
+                playlistMemoryStorage: StaticMemoryStorage,
                 customData: PT.customPlaylistDataType) {
         self.registeredTags = registeredTags
         self.structure = PT.playlistStructureType(withTags: tags)
         self.customData = customData
-        self.playlistData = playlistData
+        self.playlistMemoryStorage = playlistMemoryStorage
     }
     
     /**

--- a/mambaSharedFramework/HLS Models/URLDataPlaylistExtensions.swift
+++ b/mambaSharedFramework/HLS Models/URLDataPlaylistExtensions.swift
@@ -28,13 +28,13 @@ public struct PlaylistURLData {
 extension PlaylistCore: PlaylistURLDataInterface where PT.customPlaylistDataType == PlaylistURLData {
     
     public init(playlist: PlaylistCore) {
-        self.init(url: playlist.url, tags: playlist.tags, registeredTags: playlist.registeredTags, playlistData: playlist.playlistData)
+        self.init(url: playlist.url, tags: playlist.tags, registeredTags: playlist.registeredTags, playlistMemoryStorage: playlist.playlistMemoryStorage)
     }
     
     // care should be taken when constructing `Playlist`s manually. Users should construct these objects using `Parser`.
-    public init(url: URL, tags: [HLSTag], registeredTags: RegisteredHLSTags, playlistData: Data) {
+    public init(url: URL, tags: [HLSTag], registeredTags: RegisteredHLSTags, playlistMemoryStorage: StaticMemoryStorage) {
         let customData = PlaylistURLData(url: url)
-        self.init(tags: tags, registeredTags: registeredTags, playlistData: playlistData, customData: customData)
+        self.init(tags: tags, registeredTags: registeredTags, playlistMemoryStorage: playlistMemoryStorage, customData: customData)
     }
     
     public var url: URL {

--- a/mambaSharedFramework/HLS Rapid Parser/HLSRapidParser.h
+++ b/mambaSharedFramework/HLS Rapid Parser/HLSRapidParser.h
@@ -19,11 +19,12 @@
 
 @import Foundation;
 #include "RapidParserError.h"
+#include "StaticMemoryStorage.h"
 
 @protocol HLSRapidParserCallback;
 
 @interface HLSRapidParser : NSObject
 
-- (void)parseHLSData:(NSData * _Nonnull)data callback:(id<HLSRapidParserCallback> _Nonnull)callback;
+- (void)parseHLSData:(StaticMemoryStorage * _Nonnull)storage callback:(id<HLSRapidParserCallback> _Nonnull)callback;
 
 @end

--- a/mambaSharedFramework/HLS Rapid Parser/StaticMemoryStorage.h
+++ b/mambaSharedFramework/HLS Rapid Parser/StaticMemoryStorage.h
@@ -1,0 +1,60 @@
+//
+//  StaticMemoryStorage.h
+//  mamba
+//
+//  Created by David Coufal on 4/15/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ Minimal memory storage wrapper.
+ 
+ This class takes a NSData instance and makes a static copy of the memory for reference.
+ 
+ StaticMemoryStorage will allocate and deallocate this memory on initialization and deinitialization,
+ respectively.
+ 
+ This is done so that mamba can construct `HLSStringRef` objects that refer to this static memory
+ storage. See `HLSPlaylistCore` for where we keep a reference to this `StaticMemoryStorage` object.
+ */
+@interface StaticMemoryStorage : NSObject
+
+/**
+ Instantiates an StaticMemoryStorage with the contents of the provided NSData.
+ This will make a static copy of the data in the NSData object, owned by the StaticMemoryStorage.
+ */
+- (instancetype _Nonnull)initWithData:(NSData * _Nonnull)data;
+
+/**
+ Instantiates an empty StaticMemoryStorage. `length` and `bytes` will be zero.
+ */
+- (instancetype _Nonnull)init;
+
+/**
+ Length of the internal buffer in bytes.
+ */
+@property (nonatomic, readonly) NSUInteger length;
+
+/**
+ A pointer to the start of the memory buffer that this class wraps.
+ 
+ @warning You cannot access memory before `bytes` or after `bytes` + `length - 1` safely.
+ 
+ @warning You must not modify memory in this area. This is a read-only object.
+ */
+@property (nonatomic, readonly) const void * _Nullable bytes;
+
+@end

--- a/mambaSharedFramework/HLS Rapid Parser/StaticMemoryStorage.m
+++ b/mambaSharedFramework/HLS Rapid Parser/StaticMemoryStorage.m
@@ -1,0 +1,61 @@
+//
+//  StaticMemoryStorage.m
+//  mamba
+//
+//  Created by David Coufal on 4/15/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+#import "StaticMemoryStorage.h"
+
+@implementation StaticMemoryStorage
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _length = 0;
+        _bytes = 0;
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(const NSData *)data {
+    self = [super init];
+    if (self) {
+        void *buffer = malloc(data.length);
+        [data getBytes:buffer length:data.length];
+        _bytes = buffer;
+        _length = data.length;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    if (_bytes > 0) {
+        free((void *)_bytes);
+        _bytes = 0;
+    }
+    _length = 0;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"StaticMemoryStorage bytes:%lu length:%lu", (unsigned long)[self bytes], [self length]];
+}
+
+- (id)debugQuickLookObject {
+    return [self description];
+}
+
+@end

--- a/mambaSharedFramework/HLS Utils/Collections/CollectionType+FindExtensions.swift
+++ b/mambaSharedFramework/HLS Utils/Collections/CollectionType+FindExtensions.swift
@@ -22,7 +22,7 @@ import Foundation
 public extension Collection {
     
     // Finds the first index _after_ the parameter index that matches the predicate
-    public func findIndexAfterIndex(index:Self.Index, predicate: (Self.SubSequence.Iterator.Element) throws -> Bool) rethrows -> Self.Index? {
+    func findIndexAfterIndex(index:Self.Index, predicate: (Self.SubSequence.Iterator.Element) throws -> Bool) rethrows -> Self.Index? {
         
         guard indicies(containsIndex: index) else { return nil }
         
@@ -42,7 +42,7 @@ public extension Collection {
     }
     
     // Finds the first index _before_ the parameter index that matches the predicate
-    public func findIndexBeforeIndex(index:Self.Index, predicate: (Self.SubSequence.Iterator.Element) throws -> Bool) rethrows -> Self.Index? {
+    func findIndexBeforeIndex(index:Self.Index, predicate: (Self.SubSequence.Iterator.Element) throws -> Bool) rethrows -> Self.Index? {
         
         guard indicies(containsIndex: index) || index == self.endIndex else { return nil }
 

--- a/mambaSharedFramework/HLS Utils/Collections/CollectionType+Safe.swift
+++ b/mambaSharedFramework/HLS Utils/Collections/CollectionType+Safe.swift
@@ -34,7 +34,7 @@ extension Collection {
 /// http://stackoverflow.com/questions/25329186/safe-bounds-checked-array-lookup-in-swift-through-optional-bindings
 public extension Collection {
     /// Returns the element at the specified index iff it is within bounds, otherwise nil.
-    public subscript (safe index: Index) -> Iterator.Element? {
+    subscript (safe index: Index) -> Iterator.Element? {
         return indicies(containsIndex: index) ? self[index] : nil
     }
 }

--- a/mambaSharedFramework/HLS Utils/Collections/HLSTagArray+RenditionGroups.swift
+++ b/mambaSharedFramework/HLS Utils/Collections/HLSTagArray+RenditionGroups.swift
@@ -32,7 +32,7 @@ public enum FileType {
 public extension Collection where Iterator.Element == HLSTag {
     
     /// returns the FileType of this tag collection (i.e. master vs. variant)
-    public func type() -> FileType {
+    func type() -> FileType {
         
         for tag in self {
             if tag.tagDescriptor == PantosTag.EXTINF {
@@ -46,14 +46,14 @@ public extension Collection where Iterator.Element == HLSTag {
     }
     
     /// returns true if we can detect a SAP stream (only works for master playlists)
-    public func hasSap() -> Bool {
+    func hasSap() -> Bool {
         
         let languages = Set(self.extractValues(tagDescriptor: PantosTag.EXT_X_MEDIA, valueIdentifier: PantosValue.language))
         return languages.count > 1
     }
     
     /// returns the #EXT-X-MEDIA tags for SAP audio streams if present (only works for master playlists)
-    public func sapStreams() -> [HLSTag]? {
+    func sapStreams() -> [HLSTag]? {
         
         return self.filter({ $0.tagDescriptor == PantosTag.EXT_X_MEDIA }).filter({
             return $0.value(forValueIdentifier: PantosValue.language) != nil
@@ -61,7 +61,7 @@ public extension Collection where Iterator.Element == HLSTag {
     }
     
     /// Convenience function to return all the values for a particular HLSTagValueIdentifier in a particular HLSTagDescriptor
-    public func extractValues(tagDescriptor: HLSTagDescriptor, valueIdentifier: HLSTagValueIdentifier) -> Set<String> {
+    func extractValues(tagDescriptor: HLSTagDescriptor, valueIdentifier: HLSTagValueIdentifier) -> Set<String> {
         
         var values = Set<String>()
         let media = self.filter({ $0.tagDescriptor == tagDescriptor })
@@ -77,45 +77,48 @@ public extension Collection where Iterator.Element == HLSTag {
     }
     
     /// returns true if we are a master playlist and have a audio only stream
-    public func hasAudioOnlyStream() -> Bool {
+    func hasAudioOnlyStream() -> Bool {
         
         guard let _ = firstAudioOnlyStreamInfTag() else { return false }
         return true
     }
     
     /// returns the first audio only #EXT-X-STREAMINF tag found in this HLSTag collection
-    public func firstAudioOnlyStreamInfTag() -> HLSTag? {
+    func firstAudioOnlyStreamInfTag() -> HLSTag? {
         return first(where: { $0.tagDescriptor == PantosTag.EXT_X_STREAM_INF && $0.isAudioOnlyStream() == .TRUE })
     }
     
     /// Convenience function to filter HLSTag collections by a particular HLSTagDescriptor
-    public func filtered(by tagDescriptor: HLSTagDescriptor) -> [HLSTag] {
+    func filtered(by tagDescriptor: HLSTagDescriptor) -> [HLSTag] {
         
         return self.filter({ $0.tagDescriptor == tagDescriptor })
     }
 
     /// Convenience function to return just the video streams in a HLSTag collection
-    public func filteredByVideoCodec() -> [HLSTag] {
+    func filteredByVideoCodec() -> [HLSTag] {
         
         return self.filter { return $0.isVideoStream() == .TRUE }
     }
     
     /// returns a new HLSTag Array that's sorted by resolution and bandwidth (in that order)
-    public func sortedByResolutionBandwidth(tolerance: Double = 1.0) -> [HLSTag] {
+    func sortedByResolutionBandwidth(tolerance: Double = 1.0) -> [HLSTag] {
         
         return self.sorted { (a, b) -> Bool in
-        
+            
             if let aResolution: HLSResolution = a.resolution(),
                 let bResolution: HLSResolution = b.resolution() {
                 if aResolution < bResolution { return true }
-                if bResolution > aResolution { return false }
+                if aResolution > bResolution { return false }
+            }
+            else if let _ = b.resolution() {
+                return true
             }
             
             if let aBandwidth: Double = a.bandwidth(),
                 let bBandwidth: Double = b.bandwidth() {
                 if aBandwidth * tolerance < bBandwidth { return true }
             }
-
+            
             return false
         }
     }

--- a/mambaSharedFramework/HLS Utils/CoreMedia+Util.swift
+++ b/mambaSharedFramework/HLS Utils/CoreMedia+Util.swift
@@ -31,7 +31,7 @@ public extension CMTime {
 
 public extension CMTimeScale {
     // the default CMTime time scale for Mamba
-    static public var defaultMambaTimeScale:Int32 {
+    static var defaultMambaTimeScale: Int32 {
         return Int32(__exp10(Double(CMTime.defaultMambaPrecision)))
     }
 }

--- a/mambaSharedFramework/HLS Utils/HLSStringRef+mamba.swift
+++ b/mambaSharedFramework/HLS Utils/HLSStringRef+mamba.swift
@@ -21,11 +21,11 @@ import Foundation
 
 public extension HLSStringRef {
     
-    public convenience init(descriptor: HLSTagDescriptor) {
+    convenience init(descriptor: HLSTagDescriptor) {
         self.init(string: "#\(descriptor.toString())")
     }
 
-    public convenience init(valueIdentifier: HLSTagValueIdentifier) {
+    convenience init(valueIdentifier: HLSTagValueIdentifier) {
         self.init(string: valueIdentifier.toString())
     }
 }

--- a/mambaSharedFramework/HLS Utils/HLSTag+Util.swift
+++ b/mambaSharedFramework/HLS Utils/HLSTag+Util.swift
@@ -22,17 +22,17 @@ import Foundation
 public extension HLSTag {
     
     /// convenience function to return the resolution of this tag (if present)
-    public func resolution() -> HLSResolution? {
+    func resolution() -> HLSResolution? {
         return self.value(forValueIdentifier: PantosValue.resolution)
     }
     
     /// convenience function to return the bandwidth of this tag (if present)
-    public func bandwidth() -> Double? {
+    func bandwidth() -> Double? {
         return self.value(forValueIdentifier: PantosValue.bandwidthBPS)
     }
     
     /// convenience function to return the codecs of this tag (if present)
-    public func codecs() -> HLSCodecArray? {
+    func codecs() -> HLSCodecArray? {
         if let value: String = self.value(forValueIdentifier: PantosValue.codecs) {
             return HLSCodecArray(string: value)
         }
@@ -41,12 +41,12 @@ public extension HLSTag {
     }
     
     /// convenience function to return the language of this tag (if present)
-    public func language() -> String? {
+    func language() -> String? {
         return self.value(forValueIdentifier: PantosValue.language)
     }
     
     /// convenience function to determine if this tag contains only an audio stream (will return false if called on a non-#EXT-X-STREAM-INF tag)
-    public func isAudioOnlyStream() -> IndeterminateBool {
+    func isAudioOnlyStream() -> IndeterminateBool {
         guard tagDescriptor == PantosTag.EXT_X_STREAM_INF else {
             return .FALSE
         }
@@ -62,7 +62,7 @@ public extension HLSTag {
     }
     
     /// convenience function to determine if this tag contains a video stream (will return false if called on a non-#EXT-X-STREAM-INF tag)
-    public func isVideoStream() -> IndeterminateBool {
+    func isVideoStream() -> IndeterminateBool {
         guard tagDescriptor == PantosTag.EXT_X_STREAM_INF else {
             return .FALSE
         }
@@ -78,7 +78,7 @@ public extension HLSTag {
     }
     
     /// convenience function to determine if this tag contains both an audio and a video stream (will return false if called on a non-#EXT-X-STREAM-INF tag)
-    public func isAudioVideoStream() -> IndeterminateBool {
+    func isAudioVideoStream() -> IndeterminateBool {
         guard tagDescriptor == PantosTag.EXT_X_STREAM_INF else {
             return .FALSE
         }
@@ -90,7 +90,7 @@ public extension HLSTag {
     }
 
     /// convenience function to determine if this tag is a SAP audio stream (will return false if we are not an appropriate tag to query for this info)
-    public func isSapStream() -> Bool {
+    func isSapStream() -> Bool {
         return self.language() != nil
     }
 }

--- a/mambaSharedFramework/HLSTagDescriptor.swift
+++ b/mambaSharedFramework/HLSTagDescriptor.swift
@@ -113,4 +113,9 @@ extension HLSTagDescriptor {
     public var hashValue: Int {
         return self.toString().hash
     }
+
+    // Hasher shunt to work around Hashable issues with protocols
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.toString())
+    }
 }

--- a/mambaSharedFramework/mamba.h
+++ b/mambaSharedFramework/mamba.h
@@ -37,4 +37,4 @@ FOUNDATION_EXPORT const unsigned char mambaVersionString[];
 #import <mamba/HLSRapidParser.h>
 #import <mamba/HLSRapidParserCallback.h>
 #import <mamba/CMTimeMakeFromString.h>
-
+#import <mamba/StaticMemoryStorage.h>

--- a/mambaTests/Helpers/Playlist+Convenience.swift
+++ b/mambaTests/Helpers/Playlist+Convenience.swift
@@ -32,12 +32,12 @@ public extension PlaylistCore where PT.customPlaylistDataType == PlaylistURLData
     
     init() {
         let registeredTags = RegisteredHLSTags()
-        self.init(url: fakePlaylistURL(), tags: [HLSTag](), registeredTags: registeredTags, playlistData: Data())
+        self.init(url: fakePlaylistURL(), tags: [HLSTag](), registeredTags: registeredTags, playlistMemoryStorage: StaticMemoryStorage())
     }
     
     init(tags: [HLSTag]) {
         let registeredTags = RegisteredHLSTags()
-        self.init(url: fakePlaylistURL(), tags: tags, registeredTags: registeredTags, playlistData: Data())
+        self.init(url: fakePlaylistURL(), tags: tags, registeredTags: registeredTags, playlistMemoryStorage: StaticMemoryStorage())
     }
     
 }

--- a/mambaTests/Parser_EventUpdateTests.swift
+++ b/mambaTests/Parser_EventUpdateTests.swift
@@ -42,14 +42,14 @@ class Parser_EventUpdateTests: XCTestCase {
                                         withPlaylistData: eventHLS2.data(using: .utf8)!,
                                         atUrl: testURL1)
         
-        XCTAssertEqual(event1.playlistData, event2.playlistData)
+        XCTAssertEqual(event1.playlistMemoryStorage, event2.playlistMemoryStorage)
         XCTAssertEqual(event2.tags.count, 19)
         
         let event3 = try! parser.update(eventVariantPlaylist: event2,
                                         withPlaylistData: eventHLS3.data(using: .utf8)!,
                                         atUrl: testURL1)
         
-        XCTAssertEqual(event1.playlistData, event3.playlistData)
+        XCTAssertEqual(event1.playlistMemoryStorage, event3.playlistMemoryStorage)
         XCTAssertEqual(event3.tags.count, 27)
     }
     
@@ -68,7 +68,7 @@ class Parser_EventUpdateTests: XCTestCase {
                                         withPlaylistData: eventHLS1.data(using: .utf8)!,
                                         atUrl: testURL1)
         
-        XCTAssertEqual(event1.playlistData, event2.playlistData)
+        XCTAssertEqual(event1.playlistMemoryStorage, event2.playlistMemoryStorage)
         XCTAssertEqual(event2.tags.count, 15)
     }
     
@@ -87,7 +87,7 @@ class Parser_EventUpdateTests: XCTestCase {
                                         withPlaylistData: eventHLS2.data(using: .utf8)!,
                                         atUrl: testURL1)
         
-        XCTAssertNotEqual(event1.playlistData, event2.playlistData)
+        XCTAssertNotEqual(event1.playlistMemoryStorage, event2.playlistMemoryStorage)
         XCTAssertEqual(event2.tags.count, 19)
     }
     
@@ -109,7 +109,7 @@ class Parser_EventUpdateTests: XCTestCase {
                                         withPlaylistData: eventHLS2.data(using: .utf8)!,
                                         atUrl: testURL1)
         
-        XCTAssertNotEqual(event1.playlistData, event2.playlistData)
+        XCTAssertNotEqual(event1.playlistMemoryStorage, event2.playlistMemoryStorage)
         XCTAssertEqual(event2.tags.count, 19)
     }
     
@@ -129,7 +129,7 @@ class Parser_EventUpdateTests: XCTestCase {
                                       withPlaylistData: vodHLS2.data(using: .utf8)!,
                                       atUrl: testURL1)
         
-        XCTAssertNotEqual(vod1.playlistData, vod2.playlistData)
+        XCTAssertNotEqual(vod1.playlistMemoryStorage, vod2.playlistMemoryStorage)
         XCTAssertEqual(vod2.tags.count, 15)
     }
     
@@ -150,7 +150,7 @@ class Parser_EventUpdateTests: XCTestCase {
                                         withPlaylistData: eventHLS2.data(using: .utf8)!,
                                         atUrl: testURL2)
         
-        XCTAssertNotEqual(event1.playlistData, event2.playlistData)
+        XCTAssertNotEqual(event1.playlistMemoryStorage, event2.playlistMemoryStorage)
         XCTAssertEqual(event2.tags.count, 19)
         XCTAssertEqual(event2.url, testURL2)
         XCTAssertNotEqual(event2.url, testURL1)
@@ -187,7 +187,7 @@ missing.ts
                                         withPlaylistData: eventHLS2.data(using: .utf8)!,
                                         atUrl: testURL1)
         
-        XCTAssertNotEqual(event1.playlistData, event2.playlistData)
+        XCTAssertNotEqual(event1.playlistMemoryStorage, event2.playlistMemoryStorage)
         XCTAssertEqual(event2.tags.count, 19)
     }
 }

--- a/mambaTests/PlaylistTests.swift
+++ b/mambaTests/PlaylistTests.swift
@@ -27,26 +27,27 @@ class PlaylistTests: XCTestCase {
         let url = URL(string:"http://test.server")!
         let registeredTags = RegisteredHLSTags()
         let data = Data()
+        let playlistMemoryStorage = StaticMemoryStorage(data: data)
         
-        let variant1 = VariantPlaylist(url: url, tags: tags, registeredTags: registeredTags, playlistData: data)
-        let master1 = MasterPlaylist(url: url, tags: tags, registeredTags: registeredTags, playlistData: data)
+        let variant1 = VariantPlaylist(url: url, tags: tags, registeredTags: registeredTags, playlistMemoryStorage: playlistMemoryStorage)
+        let master1 = MasterPlaylist(url: url, tags: tags, registeredTags: registeredTags, playlistMemoryStorage: playlistMemoryStorage)
 
         XCTAssert(variant1.url == url, "Expecting the url to match")
         XCTAssert(variant1.tags.count == tags.count, "Expecting the tags to match")
-        XCTAssert(variant1.playlistData == data, "Expecting the hls data to match")
+        XCTAssert(variant1.playlistMemoryStorage == playlistMemoryStorage, "Expecting the hls data to match")
         XCTAssert(master1.url == url, "Expecting the url to match")
         XCTAssert(master1.tags.count == tags.count, "Expecting the tags to match")
-        XCTAssert(master1.playlistData == data, "Expecting the hls data to match")
+        XCTAssert(master1.playlistMemoryStorage == playlistMemoryStorage, "Expecting the hls data to match")
 
         let variant2 = VariantPlaylist(playlist: variant1)
         let master2 = MasterPlaylist(playlist: master1)
 
         XCTAssert(variant2.url == variant1.url, "Expecting the url to match")
         XCTAssert(variant2.tags.count == variant1.tags.count, "Expecting the tags to match")
-        XCTAssert(variant2.playlistData == variant1.playlistData, "Expecting the hls data to match")
+        XCTAssert(variant2.playlistMemoryStorage == variant1.playlistMemoryStorage, "Expecting the hls data to match")
         XCTAssert(master2.url == master1.url, "Expecting the url to match")
         XCTAssert(master2.tags.count == master1.tags.count, "Expecting the tags to match")
-        XCTAssert(master2.playlistData == master1.playlistData, "Expecting the hls data to match")
+        XCTAssert(master2.playlistMemoryStorage == master1.playlistMemoryStorage, "Expecting the hls data to match")
     }
     
     func testUrlChange() {
@@ -55,8 +56,9 @@ class PlaylistTests: XCTestCase {
         let url2 = URL(string:"http://test.server2")!
         let registeredTags = RegisteredHLSTags()
         let data = Data()
-        
-        var playlist = VariantPlaylist(url: url1, tags: tags, registeredTags: registeredTags, playlistData: data)
+        let playlistMemoryStorage = StaticMemoryStorage(data: data)
+
+        var playlist = VariantPlaylist(url: url1, tags: tags, registeredTags: registeredTags, playlistMemoryStorage: playlistMemoryStorage)
         playlist.url = url2
         
         XCTAssert(playlist.url == url2, "Expecting the url to change")

--- a/mambaTests/Rapid Parsing Tests/RapidParserTests.swift
+++ b/mambaTests/Rapid Parsing Tests/RapidParserTests.swift
@@ -31,10 +31,11 @@ class RapidParserTests: XCTestCase {
         mock.expectedNumberOfLines = 19
                 
         let data = FixtureLoader.load(fixtureName: "hls_sampleMediaFile.txt")! as Data
-        
+        let storage = StaticMemoryStorage(data: data)
+
         let parser = HLSRapidParser()
         
-        parser.parseHLSData(data, callback: mock)
+        parser.parseHLSData(storage, callback: mock)
         
         self.waitForExpectations(timeout: 1, handler: { (error) in
             XCTAssertNil(error, "Unexpected error: \(error!)")
@@ -50,10 +51,11 @@ class RapidParserTests: XCTestCase {
         mock.expectation = self.expectation(description: "Parsing complete")
         
         let data = FixtureLoader.load(fixtureName: "hls_sampleMediaFile.txt")! as Data
+        let storage = StaticMemoryStorage(data: data)
         
         let parser = HLSRapidParser()
         
-        parser.parseHLSData(data, callback: mock)
+        parser.parseHLSData(storage, callback: mock)
         
         self.waitForExpectations(timeout: 1, handler: { (error) in
             XCTAssertNil(error, "Unexpected error: \(error!)")

--- a/mambaTests/StaticMemoryStorageTests.m
+++ b/mambaTests/StaticMemoryStorageTests.m
@@ -1,0 +1,54 @@
+//
+//  StaticMemoryStorageTests.m
+//  mamba
+//
+//  Created by David Coufal on 4/15/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+@import mamba;
+
+@interface StaticMemoryStorageTests : XCTestCase
+
+@end
+
+@implementation StaticMemoryStorageTests
+
+- (void)testMemoryCopy {
+    NSData *data = [NSData dataWithBytes:"abcdefg" length:7];
+    StaticMemoryStorage *buffer = [[StaticMemoryStorage alloc] initWithData:data];
+    
+    const char * databytes = data.bytes;
+    const char * bufferbytes = buffer.bytes;
+    
+    XCTAssertEqual(databytes[0], bufferbytes[0]);
+    XCTAssertEqual(databytes[1], bufferbytes[1]);
+    XCTAssertEqual(databytes[2], bufferbytes[2]);
+    XCTAssertEqual(databytes[3], bufferbytes[3]);
+    XCTAssertEqual(databytes[4], bufferbytes[4]);
+    XCTAssertEqual(databytes[5], bufferbytes[5]);
+    XCTAssertEqual(databytes[6], bufferbytes[6]);
+    
+    XCTAssertEqual(data.length, buffer.length);
+}
+
+- (void)testEmptyBuffer {
+    StaticMemoryStorage *buffer = [[StaticMemoryStorage alloc] init];
+    
+    XCTAssertEqual(buffer.bytes, (char *)0);
+    XCTAssertEqual(buffer.length, 0);
+}
+
+@end


### PR DESCRIPTION


### Description

This PR implements StaticMemoryStorage, Xcode 10.2 fixes and Resolution Sort fixes from the 1.x branch.

For reference, the 1.x PRs:

* https://github.com/Comcast/mamba/pull/47
* https://github.com/Comcast/mamba/pull/48

### Change Notes

* Added new class `StaticMemoryStorage ` as a more reliable memory buffer solution.
* Xcode 10.2 fixes.
* Fixing sorting by resolution.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
