### PR TITLE
Adding Segment Info Query for Variants

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -260,6 +260,12 @@
 		EC44248C1E9694C600AECFAB /* PlaylistTagGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC44248B1E9694C600AECFAB /* PlaylistTagGroup.swift */; };
 		EC44248D1E9694C600AECFAB /* PlaylistTagGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC44248B1E9694C600AECFAB /* PlaylistTagGroup.swift */; };
 		EC44E7661DEE2F9E0087C890 /* EXT_X_MAPTagParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CD2E791DE4D46F002510E7 /* EXT_X_MAPTagParserTests.swift */; };
+		EC676A6822AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */; };
+		EC676A6922AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */; };
+		EC676A6A22AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */; };
+		EC676A6C22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */; };
+		EC676A6D22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */; };
+		EC676A6E22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */; };
 		EC7491461DD299B400AF4E20 /* PlaylistTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491421DD299B400AF4E20 /* PlaylistTypes.swift */; };
 		EC7491471DD299B400AF4E20 /* PlaylistTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491421DD299B400AF4E20 /* PlaylistTypes.swift */; };
 		EC7491591DD29AED00AF4E20 /* PlaylistTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491521DD29AED00AF4E20 /* PlaylistTag.swift */; };
@@ -712,6 +718,8 @@
 		EC42A5F41FD9BF0500317EA5 /* IndeterminateBoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndeterminateBoolTests.swift; sourceTree = "<group>"; };
 		EC44248B1E9694C600AECFAB /* PlaylistTagGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistTagGroup.swift; sourceTree = "<group>"; };
 		EC5B87A91D947B59005F68C4 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/AVFoundation.framework; sourceTree = DEVELOPER_DIR; };
+		EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantPlaylistTagMatchSegmentInfo.swift; sourceTree = "<group>"; };
+		EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantPlaylistTagMatchSegmentInfoTests.swift; sourceTree = "<group>"; };
 		EC7491421DD299B400AF4E20 /* PlaylistTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistTypes.swift; sourceTree = "<group>"; };
 		EC7491521DD29AED00AF4E20 /* PlaylistTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistTag.swift; sourceTree = "<group>"; };
 		EC74915F1DD29B0F00AF4E20 /* CoreMedia+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CoreMedia+Util.swift"; sourceTree = "<group>"; };
@@ -1009,6 +1017,7 @@
 				ECAFFA152239B81100A6D5F4 /* PlaylistStructureAndEditingTests.swift */,
 				ECAFFA19223AC6D900A6D5F4 /* PlaylistStructureMasterTests.swift */,
 				ECAFFA1D223AC85000A6D5F4 /* PlaylistStructureTests.swift */,
+				ECC410661EA1527700B4E3C8 /* PlaylistTagGroupTests.swift */,
 				ECAFFA21223ADAC900A6D5F4 /* PlaylistTests.swift */,
 				ECAFFA25223ADF0500A6D5F4 /* PlaylistTimelineAndSequencingTests.swift */,
 				EC74923B1DD29E7300AF4E20 /* PlaylistWriterTests.swift */,
@@ -1020,13 +1029,13 @@
 				0173AB081D5BB304005DE51B /* Tag Validator Tests */,
 				EC3B57F51D36CD11006656C3 /* Tag Writer Tests */,
 				EC073F591FE072DC00689228 /* TagCollectionTests.swift */,
-				ECC410661EA1527700B4E3C8 /* PlaylistTagGroupTests.swift */,
 				ECCF2DAC1E23F54100D7C48B /* TagTests.swift */,
 				EC7492521DD29E9A00AF4E20 /* TagWriting.swift */,
 				EC7492A01DD29F4600AF4E20 /* ThirdPartyTagListSupportTests.swift */,
 				EC86853F1D667907004551B8 /* Util Tests */,
 				ECAFFA29223AF6E700A6D5F4 /* ValidatorTests.swift */,
 				ECDE185022387257008566BB /* VariantPlaylistMediaSpanTests.swift */,
+				EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */,
 			);
 			path = mambaTests;
 			sourceTree = "<group>";
@@ -1284,6 +1293,7 @@
 			children = (
 				ECDE183F22381146008566BB /* MasterPlaylist.swift */,
 				ECDE18432238114E008566BB /* VariantPlaylist.swift */,
+				EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */,
 			);
 			path = "Playlist Concrete Types";
 			sourceTree = "<group>";
@@ -1823,6 +1833,7 @@
 				D4BB018D1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift in Sources */,
 				EC7491881DD29CCB00AF4E20 /* StringArrayParser.swift in Sources */,
 				EC7491D81DD29D9600AF4E20 /* GenericDictionaryTagParser.swift in Sources */,
+				EC676A6822AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift in Sources */,
 				EC03B6681E5CC56B00BF1F97 /* RapidParserLineState.c in Sources */,
 				EC7491EB1DD29DBB00AF4E20 /* GenericDictionaryTagWriter.swift in Sources */,
 				EC03B6641E5CC56B00BF1F97 /* RapidParserError.m in Sources */,
@@ -1887,6 +1898,7 @@
 				F7CFF27E1F392009009F4C82 /* CMTimeMakeFromStringTests.swift in Sources */,
 				EC74927E1DD29EC800AF4E20 /* GenericNoDataTagParserTests.swift in Sources */,
 				EC74924A1DD29E7300AF4E20 /* PlaylistWriterTests.swift in Sources */,
+				EC676A6C22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */,
 				EC74928A1DD29F1500AF4E20 /* GenericDictionaryTagValidatorTests.swift in Sources */,
 				EC073F601FE08F7500689228 /* String+Helio.swift in Sources */,
 				EC74922C1DD29E4A00AF4E20 /* Playlist+Convenience.swift in Sources */,
@@ -1989,6 +2001,7 @@
 				D4BB018E1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift in Sources */,
 				EC7491891DD29CCB00AF4E20 /* StringArrayParser.swift in Sources */,
 				EC7491D91DD29D9600AF4E20 /* GenericDictionaryTagParser.swift in Sources */,
+				EC676A6922AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift in Sources */,
 				EC03B6691E5CC56B00BF1F97 /* RapidParserLineState.c in Sources */,
 				EC7491EC1DD29DBB00AF4E20 /* GenericDictionaryTagWriter.swift in Sources */,
 				EC03B6651E5CC56B00BF1F97 /* RapidParserError.m in Sources */,
@@ -2053,6 +2066,7 @@
 				EC7492731DD29EC800AF4E20 /* EXT_X_ALLOW_CACHETagParserTests.swift in Sources */,
 				EC44E7661DEE2F9E0087C890 /* EXT_X_MAPTagParserTests.swift in Sources */,
 				EC74927F1DD29EC800AF4E20 /* GenericNoDataTagParserTests.swift in Sources */,
+				EC676A6D22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */,
 				EC74924B1DD29E7300AF4E20 /* PlaylistWriterTests.swift in Sources */,
 				EC073F611FE08F7500689228 /* String+Helio.swift in Sources */,
 				EC74928B1DD29F1500AF4E20 /* GenericDictionaryTagValidatorTests.swift in Sources */,
@@ -2155,6 +2169,7 @@
 				EC1CCD5F209A2CF9006B59FF /* PlaylistTagWriter.swift in Sources */,
 				EC1CCD49209A2CF9006B59FF /* PlaylistCollectionValidator.swift in Sources */,
 				EC1CCD37209A2CF9006B59FF /* GenericDictionaryTagParser.swift in Sources */,
+				EC676A6A22AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift in Sources */,
 				EC1CCD28209A2CF9006B59FF /* FailableStringLiteralConvertible.swift in Sources */,
 				EC1CCCF7209A2CF9006B59FF /* StructureState.swift in Sources */,
 				EC1CCD5C209A2CF9006B59FF /* PlaylistTagParser.swift in Sources */,
@@ -2219,6 +2234,7 @@
 				ECE253FF209A50B500D388CE /* CollectionTypeTests.swift in Sources */,
 				ECE253FE209A50B500D388CE /* CMTimeMakeFromStringTests.swift in Sources */,
 				ECE253EC209A50A100D388CE /* RapidParserTests.swift in Sources */,
+				EC676A6E22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */,
 				ECE253FC209A50B500D388CE /* GenericSingleTagWriterTests.swift in Sources */,
 				ECAFFA1C223AC6D900A6D5F4 /* PlaylistStructureMasterTests.swift in Sources */,
 				ECE253F4209A50B500D388CE /* EXT_X_PROGRAM_DATE_TIMEParserTests.swift in Sources */,

--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/VariantPlaylistTagMatchSegmentInfo.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/VariantPlaylistTagMatchSegmentInfo.swift
@@ -1,0 +1,137 @@
+//
+//  VariantPlaylistTagMatchSegmentInfo.swift
+//  mamba
+//
+//  Created by David Coufal on 6/10/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import Foundation
+
+extension PlaylistCore where PT == VariantPlaylistType {
+    
+    /**
+     Query a variant playlist segment-based info with a predicate based on tags.
+     
+     It's pretty common to want to know "what segment(s) in my variant playlist have a particular tag
+     descriptor?" This is useful for a variety of signaling situations. This function is syntatic sugar
+     to easily get access to this info.
+     
+     Example: Your media server places signals for "chapters" in your variant playlists. You can use this
+     function to figure out when those signals appear so you can create a custom UI for this media. The
+     code might look something like this:
+     
+     ```
+     let chapterMarkSegments = variantPlaylist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == ChapterMarkTagDescriptor.EXT_X_CHAPTERMARK })
+     for chapterMarkSegment in chapterMarkSegments {
+       // tell the UI about the chapter mark time
+       switch (chapterMarkSegment.playlistTime) {
+         case .timeMatch(let timeRange):
+           markChapter(atTime: timeRange.start)
+         default:
+           break
+       }
+     }
+     ```
+     
+     - parameter usingPredicate: A `VariantPlaylistTagMatchPredicate` closure that is used to select individual
+     tags in the playlist. Any segments containing those tags will be returned in the result to this call.
+     
+     - parameter withMatchesInHeaderMatchingToFirstMediaSegment: Asks the algorithm to treat matching tags in
+     the "header" section of the playlist as if they belong to the first segment. Since this is generally
+     correct behavior for HLS, this defaults to `true` but it can be turned off if that behavior is not desireable.
+     
+     - returns: An array of `VariantPlaylistTagMatchSegmentInfo` structs describing each hit. (Note that if you have
+     more than one hit per segment your segment will show up more than once).
+     */
+    public func getPlaylistSegmentMatches(usingPredicate predicate: VariantPlaylistTagMatchPredicate,
+                                          withMatchesInHeaderMatchingToFirstMediaSegment matchesInHeaderMatchToFirst: Bool = true) -> [VariantPlaylistTagMatchSegmentInfo] {
+        
+        let matchingTagIndices = tags.indices.filter { predicate(tags[$0]) }
+        
+        var matches = [VariantPlaylistTagMatchSegmentInfo]()
+        
+        for tagIndex in matchingTagIndices {
+            
+            let matchingMediaGroup: MediaSegmentPlaylistTagGroup
+            let foundInHeader: Bool
+            
+            if let mediaGroup = mediaGroup(forTagIndex: tagIndex) {
+                matchingMediaGroup = mediaGroup
+                foundInHeader = false
+            }
+            else if matchesInHeaderMatchToFirst, let firstMediaGroup = mediaSegmentGroups.first {
+                matchingMediaGroup = firstMediaGroup
+                foundInHeader = true
+            }
+            else {
+                // our tag match must be in the footer...
+                continue
+            }
+            
+            guard let tagGroupIndex = mediaSegmentGroups.firstIndex(of: matchingMediaGroup) else {
+                assertionFailure("We should be able to find the index of the media group that we just found.")
+                continue
+            }
+            
+            let playlistTime: PlaylistTimeMatch
+            if canQueryTimeline() {
+                playlistTime = .timeMatch(matchingMediaGroup.timeRange)
+            }
+            else {
+                playlistTime = .noTimeMatchForNonVODPlaylist
+            }
+            
+            matches.append(VariantPlaylistTagMatchSegmentInfo(tagIndex: tagIndex,
+                                                              mediaSequence: matchingMediaGroup.mediaSequence,
+                                                              playlistTime: playlistTime,
+                                                              tagIndexRangeOfMediaGroup: matchingMediaGroup.range,
+                                                              tagGroupIndex: tagGroupIndex,
+                                                              containsDiscontinuity: matchingMediaGroup.discontinuity,
+                                                              foundInHeader: foundInHeader))
+        }
+        
+        return matches
+    }
+}
+
+/// A closure to determine if a given `PlaylistTag` is a match for a filter.
+public typealias VariantPlaylistTagMatchPredicate = (PlaylistTag) -> (Bool)
+
+/// A struct containing info about a segment match in a variant playlist.
+public struct VariantPlaylistTagMatchSegmentInfo {
+    /// The index of the tag in the tag array of the original playlist.
+    public let tagIndex: Int
+    /// The media sequence number of the segment where the match occurred.
+    public let mediaSequence: MediaSequence
+    /// The time in the VOD playlist of the segment where the match occurred (will be `.noTimeMatchForNonVODPlaylist` for non VOD playlists).
+    public let playlistTime: PlaylistTimeMatch
+    /// The tag index range (of the playlist tag array) of the segment where the match occurred.
+    public let tagIndexRangeOfMediaGroup: PlaylistTagIndexRange
+    /// The tag group index (of the `mediaSegmentGroups` array) of the segment where the match occurred.
+    public let tagGroupIndex: Int
+    /// The discontinuity status of the segment where the match occurred.
+    public let containsDiscontinuity: Bool
+    /// True if the match was found in the "header" of the playlist, false otherwise.
+    public let foundInHeader: Bool
+}
+
+/// An enum value representing the time status of a VariantPlaylistTagMatchSegmentInfo
+public enum PlaylistTimeMatch {
+    /// We do not have a time match as the playlist was not a VOD playlist.
+    case noTimeMatchForNonVODPlaylist
+    /// A time match for the segment from a VOD playlist.
+    case timeMatch(CMTimeRange)
+}
+

--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/VariantPlaylistTagMatchSegmentInfo.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/VariantPlaylistTagMatchSegmentInfo.swift
@@ -71,7 +71,9 @@ extension PlaylistCore where PT == VariantPlaylistType {
                 matchingMediaGroup = mediaGroup
                 foundInHeader = false
             }
-            else if matchesInHeaderMatchToFirst, let firstMediaGroup = mediaSegmentGroups.first {
+            else if matchesInHeaderMatchToFirst,
+                let firstMediaGroup = mediaSegmentGroups.first,
+                header?.range.contains(tagIndex) == true {
                 matchingMediaGroup = firstMediaGroup
                 foundInHeader = true
             }

--- a/mambaSharedFramework/Playlist Models/Playlist Structure/PlaylistTagGroup.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Structure/PlaylistTagGroup.swift
@@ -64,7 +64,7 @@ public struct PlaylistTagGroup: PlaylistTagGroupProtocol, CustomDebugStringConve
  Note that we currently also use this to model variant playlist "groups" in master playlists.
  This is convenient but not semantically correct.
  */
-public struct MediaSegmentPlaylistTagGroup: PlaylistTagGroupProtocol, CustomDebugStringConvertible {
+public struct MediaSegmentPlaylistTagGroup: PlaylistTagGroupProtocol, CustomDebugStringConvertible, Equatable {
     
     public var range: PlaylistTagIndexRange
     
@@ -76,6 +76,15 @@ public struct MediaSegmentPlaylistTagGroup: PlaylistTagGroupProtocol, CustomDebu
         return "MediaSegmentPlaylistTagGroup startIndex: \(startIndex) endIndex:\(endIndex) mediaSequence:\(mediaSequence) timeRange:\(timeRange) discontinuity:\(discontinuity)"
     }
 }
+
+public func ==(lhs: MediaSegmentPlaylistTagGroup, rhs: MediaSegmentPlaylistTagGroup) -> Bool {
+    
+    return lhs.mediaSequence == rhs.mediaSequence &&
+        lhs.range == rhs.range &&
+        lhs.timeRange == rhs.timeRange &&
+        lhs.discontinuity == rhs.discontinuity
+}
+
 
 /**
  An object to model the tags that are all "spanned" by one particualr tag.

--- a/mambaSharedFramework/Utils/Collections/PlaylistTagArray+RenditionGroups.swift
+++ b/mambaSharedFramework/Utils/Collections/PlaylistTagArray+RenditionGroups.swift
@@ -38,7 +38,13 @@ public extension Collection where Iterator.Element == PlaylistTag {
             if tag.tagDescriptor == PantosTag.EXTINF {
                 return .media
             }
+            if tag.tagDescriptor == PantosTag.EXT_X_TARGETDURATION {
+                return .media
+            }
             if tag.tagDescriptor == PantosTag.EXT_X_STREAM_INF {
+                return .master
+            }
+            if tag.tagDescriptor == PantosTag.EXT_X_MEDIA {
                 return .master
             }
         }

--- a/mambaTests/VariantPlaylistTagMatchSegmentInfoTests.swift
+++ b/mambaTests/VariantPlaylistTagMatchSegmentInfoTests.swift
@@ -1,0 +1,254 @@
+//
+//  VariantPlaylistTagMatchSegmentInfoTests.swift
+//  mamba
+//
+//  Created by David Coufal on 6/11/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import XCTest
+import mamba
+
+class VariantPlaylistTagMatchSegmentInfoTests: XCTestCase {
+    
+    func testBasicFunctionality() {
+        
+        let testHLS = """
+#EXTM3U
+#EXT-X-VARIANT-WHOLE-PLAYLIST-SCOPE
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:3.00,0
+segment0.ts
+#EXTINF:3.00,1
+segment1.ts
+#EXTINF:3.00,2
+#EXT-X-VARIANT-SEGMENT-SCOPE
+segment2.ts
+#EXTINF:3.00,3
+segment3.ts
+#EXTINF:3.00,4
+#EXT-X-VARIANT-SEGMENT-SCOPE
+#EXT-X-DISCONTINUITY
+segment4.ts
+#EXTINF:3.00,5
+segment5.ts
+#EXT-X-ENDLIST
+"""
+        let playlist = parseVariantPlaylist(inString: testHLS, tagTypes: [VariantMatchTestTag.self])
+        
+        // testing if the "match in header means the match is for the first fragment" feature works (note this is the default behavior)
+        let testMatchHeaderTagsWithFirstFragment = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_WHOLE_PLAYLIST_SCOPE })
+        
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment.count, 1)
+        
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment[0].containsDiscontinuity, false)
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment[0].foundInHeader, true)
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment[0].mediaSequence, 0)
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment[0].tagGroupIndex, 0)
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment[0].tagIndex, 0)
+        XCTAssertEqual(testMatchHeaderTagsWithFirstFragment[0].tagIndexRangeOfMediaGroup, 4...5)
+        switch testMatchHeaderTagsWithFirstFragment[0].playlistTime {
+        case .noTimeMatchForNonVODPlaylist:
+            XCTFail("Not expecting this value")
+        case .timeMatch(let timeRange):
+            XCTAssertEqual(timeRange.start, CMTime.zero)
+            XCTAssertEqual(timeRange.duration, CMTime(string: "3.0000")!)
+        }
+        
+        // testing if the "match in header means no match" feature works
+        let testMatchHeaderTagsWithNothing = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_WHOLE_PLAYLIST_SCOPE },
+                                                                                withMatchesInHeaderMatchingToFirstMediaSegment: false)
+        
+        XCTAssertEqual(testMatchHeaderTagsWithNothing.count, 0)
+        
+        // testing more "normal" segment based tags
+        let testSegmentTags = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_SEGMENT_SCOPE })
+        
+        XCTAssertEqual(testSegmentTags.count, 2)
+        
+        XCTAssertEqual(testSegmentTags[0].containsDiscontinuity, false)
+        XCTAssertEqual(testSegmentTags[0].foundInHeader, false)
+        XCTAssertEqual(testSegmentTags[0].mediaSequence, 2)
+        XCTAssertEqual(testSegmentTags[0].tagGroupIndex, 2)
+        XCTAssertEqual(testSegmentTags[0].tagIndex, 9)
+        XCTAssertEqual(testSegmentTags[0].tagIndexRangeOfMediaGroup, 8...10)
+        switch testSegmentTags[0].playlistTime {
+        case .noTimeMatchForNonVODPlaylist:
+            XCTFail("Not expecting this value")
+        case .timeMatch(let timeRange):
+            XCTAssertEqual(timeRange.start, CMTime(string: "6.0000")!)
+            XCTAssertEqual(timeRange.duration, CMTime(string: "3.0000")!)
+        }
+        
+        XCTAssertEqual(testSegmentTags[1].containsDiscontinuity, true)
+        XCTAssertEqual(testSegmentTags[1].foundInHeader, false)
+        XCTAssertEqual(testSegmentTags[1].mediaSequence, 4)
+        XCTAssertEqual(testSegmentTags[1].tagGroupIndex, 4)
+        XCTAssertEqual(testSegmentTags[1].tagIndex, 14)
+        XCTAssertEqual(testSegmentTags[1].tagIndexRangeOfMediaGroup, 13...16)
+        switch testSegmentTags[1].playlistTime {
+        case .noTimeMatchForNonVODPlaylist:
+            XCTFail("Not expecting this value")
+        case .timeMatch(let timeRange):
+            XCTAssertEqual(timeRange.start, CMTime(string: "12.0000")!)
+            XCTAssertEqual(timeRange.duration, CMTime(string: "3.0000")!)
+        }
+        
+        // quick test of testing more "normal" segment based tags with "match in header means no match"
+        let testSegmentTagsHeaderNoMatch = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_SEGMENT_SCOPE },
+                                                                              withMatchesInHeaderMatchingToFirstMediaSegment: false)
+        
+        XCTAssertEqual(testSegmentTagsHeaderNoMatch.count, 2)
+        
+        // quick test for tag types that do not appear
+        let testSegmentDoesNotAppear = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_DOES_NOT_APPEAR })
+        
+        XCTAssertEqual(testSegmentDoesNotAppear.count, 0)
+    }
+    
+    func testTimesForLivePlaylist() {
+        let testHLS = """
+#EXTM3U
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXTINF:3.00,0
+segment0.ts
+#EXTINF:3.00,1
+segment1.ts
+#EXTINF:3.00,2
+#EXT-X-VARIANT-SEGMENT-SCOPE
+segment2.ts
+#EXTINF:3.00,3
+segment3.ts
+#EXTINF:3.00,4
+#EXT-X-VARIANT-SEGMENT-SCOPE
+#EXT-X-DISCONTINUITY
+segment4.ts
+#EXTINF:3.00,5
+segment5.ts
+"""
+        let playlist = parseVariantPlaylist(inString: testHLS, tagTypes: [VariantMatchTestTag.self])
+
+        let testSegmentTags = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_SEGMENT_SCOPE })
+        
+        XCTAssertEqual(testSegmentTags.count, 2)
+        
+        XCTAssertEqual(testSegmentTags[0].containsDiscontinuity, false)
+        XCTAssertEqual(testSegmentTags[0].foundInHeader, false)
+        XCTAssertEqual(testSegmentTags[0].mediaSequence, 2)
+        XCTAssertEqual(testSegmentTags[0].tagGroupIndex, 2)
+        XCTAssertEqual(testSegmentTags[0].tagIndex, 7)
+        XCTAssertEqual(testSegmentTags[0].tagIndexRangeOfMediaGroup, 6...8)
+        switch testSegmentTags[0].playlistTime {
+        case .noTimeMatchForNonVODPlaylist:
+            // expected
+            break
+        case .timeMatch(_):
+            XCTFail("Not expecting this value")
+        }
+        
+        XCTAssertEqual(testSegmentTags[1].containsDiscontinuity, true)
+        XCTAssertEqual(testSegmentTags[1].foundInHeader, false)
+        XCTAssertEqual(testSegmentTags[1].mediaSequence, 4)
+        XCTAssertEqual(testSegmentTags[1].tagGroupIndex, 4)
+        XCTAssertEqual(testSegmentTags[1].tagIndex, 12)
+        XCTAssertEqual(testSegmentTags[1].tagIndexRangeOfMediaGroup, 11...14)
+        switch testSegmentTags[1].playlistTime {
+        case .noTimeMatchForNonVODPlaylist:
+            // expected
+            break
+        case .timeMatch(_):
+            XCTFail("Not expecting this value")
+        }
+    }
+    
+    func testEmptyPlaylist() {
+        let testHLS = """
+#EXTM3U
+#EXT-X-VARIANT-WHOLE-PLAYLIST-SCOPE
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:3
+#EXT-X-VERSION:3
+#EXT-X-ENDLIST
+"""
+        let playlist = parseVariantPlaylist(inString: testHLS, tagTypes: [VariantMatchTestTag.self])
+        
+        let testSegmentTags = playlist.getPlaylistSegmentMatches(usingPredicate: { $0.tagDescriptor == VariantMatchTestTag.EXT_X_VARIANT_WHOLE_PLAYLIST_SCOPE })
+        
+        XCTAssertEqual(testSegmentTags.count, 0)
+    }
+}
+
+fileprivate enum VariantMatchTestTag: String {
+    
+    case EXT_X_VARIANT_WHOLE_PLAYLIST_SCOPE = "EXT-X-VARIANT-WHOLE-PLAYLIST-SCOPE"
+    case EXT_X_VARIANT_SEGMENT_SCOPE = "EXT-X-VARIANT-SEGMENT-SCOPE"
+    case EXT_X_VARIANT_DOES_NOT_APPEAR = "EXT-X-VARIANT-DOES-NOT-APPEAR"
+}
+
+extension VariantMatchTestTag: PlaylistTagDescriptor {
+    
+    public static func constructTag(tag: String) -> PlaylistTagDescriptor? {
+        return VariantMatchTestTag(rawValue: tag)
+    }
+    
+    public func toString() -> String {
+        return self.rawValue
+    }
+    
+    public func isEqual(toTagDescriptor tagDescriptor: PlaylistTagDescriptor) -> Bool {
+        guard let tag = tagDescriptor as? VariantMatchTestTag else {
+            return false
+        }
+        return tag.rawValue == self.rawValue
+    }
+    
+    public static func parser(forTag tag: PlaylistTagDescriptor) -> PlaylistTagParser? {
+        guard let _ = VariantMatchTestTag(rawValue: tag.toString()) else {
+            return nil
+        }
+        return GenericNoDataTagParser(tag: tag)
+    }
+    
+    public static func writer(forTag tag: PlaylistTagDescriptor) -> PlaylistTagWriter? {
+        return nil
+    }
+    
+    public static func validator(forTag tag: PlaylistTagDescriptor) -> PlaylistTagValidator? {
+        return nil
+    }
+    
+    public func scope() -> PlaylistTagDescriptorScope {
+        switch self {
+        case .EXT_X_VARIANT_SEGMENT_SCOPE:
+            return .mediaSegment
+        case .EXT_X_VARIANT_WHOLE_PLAYLIST_SCOPE:
+            return .wholePlaylist
+        case .EXT_X_VARIANT_DOES_NOT_APPEAR:
+            return .mediaSegment
+        }
+    }
+    
+    public func type() -> PlaylistTagDescriptorType {
+        return .noValue
+    }
+    
+    public static func constructDescriptor(fromStringRef string: MambaStringRef) -> PlaylistTagDescriptor? {
+        var tagName = string.stringValue()
+        tagName.remove(at: tagName.startIndex)
+        return constructTag(tag: tagName)
+    }
+}


### PR DESCRIPTION
### Description

This PR implements feature #42. It implements a feature where the user can query a `VariantPlaylist` for tags that match a predicate closure. Info about the _segments_ that the predicate tags matches belong to are returned as a result. This is useful to implement detectors for general signals in a variant playlist that "belong" to a segment.

### Change Notes

* Added new function for `VariantPlaylist`: `getPlaylistSegmentMatches(usingPredicate:)` that implements the new functionality.
* Made the `[PlaylistTag]` utility function `type()` more functional by adding more clues to trigger a decision between master and variant (this was required for one of the unit tests).

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.