### PR TITLE
Cache the `playlistType` for `VariantPlaylist`. Invalidate the cache when changes are made.

### DIFF
--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/VariantPlaylist.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/VariantPlaylist.swift
@@ -36,21 +36,7 @@ extension PlaylistCore: PlaylistTypeDetermination, PlaylistTimelineTranslator, V
     // MARK: PlaylistTypeDetermination
 
     public var playlistType: PlaylistType {
-        get {
-            guard
-                let playlistTag = tags.first(where: { $0.tagDescriptor == PantosTag.EXT_X_PLAYLIST_TYPE }),
-                let playlistType: PlaylistValueType = playlistTag.value(forValueIdentifier: PantosValue.playlistType) else {
-                    // if the #EXT-X-PLAYLIST-TYPE tag is not present, it's not 100% clear from the Pantos spec what to do.
-                    // here, we choose to check for the #EXT-X-ENDLIST tag as well. If it is present, we can assume we are VOD.
-                    // otherwise we assume live.
-                    // other checks could be added here as needed.
-                    if let _ = tags.first(where: { $0.tagDescriptor == PantosTag.EXT_X_ENDLIST }) {
-                        return .vod
-                    }
-                    return .live
-            }
-            return playlistType.type == .VOD ? .vod : .event
-        }
+        return structure.playlistType
     }
     
     internal func canQueryTimeline() -> Bool {
@@ -183,4 +169,4 @@ extension PlaylistCore: PlaylistTypeDetermination, PlaylistTimelineTranslator, V
  
  This protocol should be used instead of the actual `VariantPlaylist` type when possible.
  */
-public protocol VariantPlaylistInterface: PlaylistInterface, VariantPlaylistStructureInterface, PlaylistTimelineTranslator, PlaylistTypeDetermination, PlaylistURLDataInterface {}
+public protocol VariantPlaylistInterface: PlaylistInterface, VariantPlaylistStructureInterface, PlaylistTimelineTranslator, PlaylistURLDataInterface {}

--- a/mambaSharedFramework/Playlist Models/PlaylistInterface.swift
+++ b/mambaSharedFramework/Playlist Models/PlaylistInterface.swift
@@ -21,7 +21,7 @@ import Foundation
 
 /**
  Defines an interface for `Playlist` objects. This should be used in situations where
- a generic `Playlist` type is enough to clearly define what it required.
+ a generic `Playlist` type is enough to clearly define what is required.
  */
 public protocol PlaylistInterface: RegisteredPlaylistTagsProvider, PlaylistTagSource {
     mutating func insert(tag: PlaylistTag, atIndex index: Int)

--- a/mambaTests/PlaylistStructureAndEditingTests.swift
+++ b/mambaTests/PlaylistStructureAndEditingTests.swift
@@ -823,6 +823,53 @@ class PlaylistStructureAndEditingTests: XCTestCase {
         XCTAssert(playlist.footer?.range.count == 1, "Should have a footer")
         XCTAssert(playlist.mediaSpans.count == 2, "Should have 2 spans")
     }
+    
+    func testPlaylistTypeChanges() {
+        
+        let sampleLive = """
+#EXTM3U
+#EXT-X-VERSION:4
+#EXT-X-TARGETDURATION:2
+#EXTINF:2.002,
+fragment1.ts
+"""
+        
+        // Live -> VOD by adding a VOD playlist type
+        var playlist1 = parseVariantPlaylist(inString: sampleLive)
+        
+        XCTAssertEqual(playlist1.playlistType, .live)
+        
+        let parsedValues1: PlaylistTagDictionary = [PantosValue.playlistType.toString(): PlaylistTagValueData(value: "VOD")]
+        playlist1.insert(tag: PlaylistTag(tagDescriptor: PantosTag.EXT_X_PLAYLIST_TYPE,
+                                          stringTagData: "VOD",
+                                          parsedValues: parsedValues1),
+                         atIndex: 0)
+        
+        XCTAssertEqual(playlist1.playlistType, .vod)
+
+        // Live -> VOD by adding a ENDLIST
+        var playlist2 = parseVariantPlaylist(inString: sampleLive)
+        
+        XCTAssertEqual(playlist2.playlistType, .live)
+        
+        playlist2.insert(tag: PlaylistTag(tagDescriptor: PantosTag.EXT_X_ENDLIST),
+                         atIndex: 0)
+        
+        XCTAssertEqual(playlist2.playlistType, .vod)
+        
+        // Live -> Event by adding a EVENT playlist type
+        var playlist3 = parseVariantPlaylist(inString: sampleLive)
+        
+        XCTAssertEqual(playlist3.playlistType, .live)
+        
+        let parsedValues3: PlaylistTagDictionary = [PantosValue.playlistType.toString(): PlaylistTagValueData(value: "EVENT")]
+        playlist3.insert(tag: PlaylistTag(tagDescriptor: PantosTag.EXT_X_PLAYLIST_TYPE,
+                                          stringTagData: "EVENT",
+                                          parsedValues: parsedValues3),
+                         atIndex: 0)
+        
+        XCTAssertEqual(playlist3.playlistType, .event)
+    }
 }
 
 


### PR DESCRIPTION
### Description

This PR implements #41 .

The `playlistType` is now maintained by the `PlaylistStructure` and the `VariantPlaylist` just asks the structure for its value.

The `PlaylistStructure` value is calculated when the structure is calculated. It's recalculated whenever tag changes are made.

This should be a minor performance improvement for code that checks `playlistType` often.

### Change Notes

* Make `PlaylistTypeDetermination` part of the variant structure system.
* Store `playlistType` in the variant structure system.
* Calculate `playlistType` on init.
* Recalculate `playlistType` on both rebuild of the structure and on "changed".
* `VariantPlaylist` now just defers to the variant structure on the `playlistType` value.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.
