### PR TITLE
Add a function to summarize the stream content of a master playlist

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -266,6 +266,12 @@
 		EC676A6C22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */; };
 		EC676A6D22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */; };
 		EC676A6E22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */; };
+		EC676A7822B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A7722B05BF0008920BB /* MasterPlaylistStreamSummary.swift */; };
+		EC676A7922B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A7722B05BF0008920BB /* MasterPlaylistStreamSummary.swift */; };
+		EC676A7A22B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A7722B05BF0008920BB /* MasterPlaylistStreamSummary.swift */; };
+		EC676A7C22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A7B22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift */; };
+		EC676A7D22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A7B22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift */; };
+		EC676A7E22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC676A7B22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift */; };
 		EC7491461DD299B400AF4E20 /* PlaylistTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491421DD299B400AF4E20 /* PlaylistTypes.swift */; };
 		EC7491471DD299B400AF4E20 /* PlaylistTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491421DD299B400AF4E20 /* PlaylistTypes.swift */; };
 		EC7491591DD29AED00AF4E20 /* PlaylistTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7491521DD29AED00AF4E20 /* PlaylistTag.swift */; };
@@ -720,6 +726,8 @@
 		EC5B87A91D947B59005F68C4 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/AVFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantPlaylistTagMatchSegmentInfo.swift; sourceTree = "<group>"; };
 		EC676A6B22B00269008920BB /* VariantPlaylistTagMatchSegmentInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantPlaylistTagMatchSegmentInfoTests.swift; sourceTree = "<group>"; };
+		EC676A7722B05BF0008920BB /* MasterPlaylistStreamSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterPlaylistStreamSummary.swift; sourceTree = "<group>"; };
+		EC676A7B22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterPlaylistStreamSummaryTests.swift; sourceTree = "<group>"; };
 		EC7491421DD299B400AF4E20 /* PlaylistTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistTypes.swift; sourceTree = "<group>"; };
 		EC7491521DD29AED00AF4E20 /* PlaylistTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistTag.swift; sourceTree = "<group>"; };
 		EC74915F1DD29B0F00AF4E20 /* CoreMedia+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CoreMedia+Util.swift"; sourceTree = "<group>"; };
@@ -1008,6 +1016,7 @@
 				EC6C8F831D08C793007C1C99 /* Helpers */,
 				EC15215E1DD28536006FB265 /* Info.plist */,
 				883290551EA172170064588B /* MambaStringRefExtensionTests.swift */,
+				EC676A7B22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift */,
 				EC073F5C1FE0840000689228 /* OutputStreamExtensionTests.swift */,
 				ECFBD9141E5CCCB100379FC2 /* PantosTagTests.swift */,
 				ECAFFA002239A22800A6D5F4 /* Parser_EventUpdateTests.swift */,
@@ -1292,6 +1301,7 @@
 			isa = PBXGroup;
 			children = (
 				ECDE183F22381146008566BB /* MasterPlaylist.swift */,
+				EC676A7722B05BF0008920BB /* MasterPlaylistStreamSummary.swift */,
 				ECDE18432238114E008566BB /* VariantPlaylist.swift */,
 				EC676A6722AF0D8D008920BB /* VariantPlaylistTagMatchSegmentInfo.swift */,
 			);
@@ -1821,6 +1831,7 @@
 				EC74917D1DD29C3500AF4E20 /* String+DateParsing.swift in Sources */,
 				EC3B01AB1DD4D47900B512E3 /* EXT_X_MEDIARenditionGroupNAMEValidator.swift in Sources */,
 				EC7491651DD29B0F00AF4E20 /* FailableStringLiteralConvertible.swift in Sources */,
+				EC676A7822B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */,
 				EC7491461DD299B400AF4E20 /* PlaylistTypes.swift in Sources */,
 				EC349ACE2236C3A60077432B /* PlaylistStructureInterface.swift in Sources */,
 				EC3B01A71DD4D47900B512E3 /* EXT_X_MEDIARenditionGroupAUTOSELECTValidator.swift in Sources */,
@@ -1850,6 +1861,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EC676A7C22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift in Sources */,
 				ECAFFA2A223AF6E700A6D5F4 /* ValidatorTests.swift in Sources */,
 				EC74928C1DD29F1500AF4E20 /* GenericSingleTagValidatorTests.swift in Sources */,
 				EC7492B91DD29F8900AF4E20 /* ResolutionTests.swift in Sources */,
@@ -1989,6 +2001,7 @@
 				EC3B01C81DD4D49A00B512E3 /* PlaylistRenditionGroupMatchingNAMELANGUAGEValidator.swift in Sources */,
 				EC74917E1DD29C3500AF4E20 /* String+DateParsing.swift in Sources */,
 				EC3B01AC1DD4D47900B512E3 /* EXT_X_MEDIARenditionGroupNAMEValidator.swift in Sources */,
+				EC676A7922B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */,
 				EC7491661DD29B0F00AF4E20 /* FailableStringLiteralConvertible.swift in Sources */,
 				EC349ACF2236C3A60077432B /* PlaylistStructureInterface.swift in Sources */,
 				EC7491471DD299B400AF4E20 /* PlaylistTypes.swift in Sources */,
@@ -2018,6 +2031,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EC676A7D22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift in Sources */,
 				ECAFFA2B223AF6E700A6D5F4 /* ValidatorTests.swift in Sources */,
 				EC74928D1DD29F1500AF4E20 /* GenericSingleTagValidatorTests.swift in Sources */,
 				EC7492BA1DD29F8900AF4E20 /* ResolutionTests.swift in Sources */,
@@ -2157,6 +2171,7 @@
 				EC349AE42236F58B0077432B /* VariantPlaylistType.swift in Sources */,
 				EC1CCD47209A2CF9006B59FF /* DictionaryTagValueIdentifier.swift in Sources */,
 				EC1CCCF2209A2CF9006B59FF /* PlaylistTag.swift in Sources */,
+				EC676A7A22B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */,
 				EC1CCD4F209A2CF9006B59FF /* PlaylistTagCardinalityValidation.swift in Sources */,
 				EC1CCD2B209A2CF9006B59FF /* IndeterminateBool.swift in Sources */,
 				EC349AD02236C3A60077432B /* PlaylistStructureInterface.swift in Sources */,
@@ -2186,6 +2201,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EC676A7E22B1A99B008920BB /* MasterPlaylistStreamSummaryTests.swift in Sources */,
 				ECAFFA2C223AF6E700A6D5F4 /* ValidatorTests.swift in Sources */,
 				ECE253E8209A509C00D388CE /* OutputStreamExtensionTests.swift in Sources */,
 				ECE253EE209A50A600D388CE /* StructureStateTests.swift in Sources */,

--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
@@ -1,0 +1,461 @@
+//
+//  MasterPlaylistStreamSummary.swift
+//  mamba
+//
+//  Created by David Coufal on 6/11/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import Foundation
+
+extension PlaylistCore where PT == MasterPlaylistType {
+    
+    /**
+     Calculates a summary of all the independantly addressable (i.e. has a uri) streams in a given master HLS playlist.
+     
+     It's worth noting that this function captures the state of the playlist when it's called. The
+     `PlaylistStreamSummary` object that is returned will not update if the master playlist is edited.
+     
+     This function is also not thread safe. Please esnure that no other threads are editing this master playlist
+     while executing.
+     
+     - returns: A `Result` object with either a `PlaylistStreamSummary` for success or a `StreamSummaryError` for failure.
+     */
+    public func calculateStreamSummary() -> Result<PlaylistStreamSummary, StreamSummaryError> {
+        
+        var streams = [PlaylistStream]()
+        var nonStreamMediaGroupInfo = [NonStreamMediaGroupInfo]()
+        
+        // parse iframe streams
+        let iFrameStreamInfIndices = tags.indices.filter { tags[$0].tagDescriptor == PantosTag.EXT_X_I_FRAME_STREAM_INF }
+        for iFrameStreamInfIndex in iFrameStreamInfIndices {
+            guard let mediaTag = tags[safe: iFrameStreamInfIndex] else {
+                assertionFailure("It's odd that the index we just calculated for the iframestreaminf tag is no longer valid")
+                return .failure(.internalIndexError)
+            }
+            guard let uri: String = mediaTag.value(forValueIdentifier: PantosValue.uri) else {
+                return .failure(.invalidMasterPlaylistError(errorText: "URI is required for iFrameStreamInf tags"))
+            }
+            streams.append(.iFrameStream(iFrameStreamInfIndex: iFrameStreamInfIndex, uri: uri))
+        }
+        
+        // parse the media streams
+        let mediaIndices = tags.indices.filter { tags[$0].tagDescriptor == PantosTag.EXT_X_MEDIA }
+        for mediaIndex in mediaIndices {
+            guard let mediaTag = tags[safe: mediaIndex] else {
+                assertionFailure("It's odd that the index we just calculated for the media tag is no longer valid")
+                return .failure(.internalIndexError)
+            }
+            guard
+                let type: MediaType = mediaTag.value(forValueIdentifier: PantosValue.type) else {
+                    return .failure(.invalidMasterPlaylistError(errorText: "Type is required for media tags"))
+            }
+            guard type != .ClosedCaptions else {
+                // not an error!
+                continue
+            }
+            guard
+                let groupId: String = mediaTag.value(forValueIdentifier: PantosValue.groupId),
+                let name: String = mediaTag.value(forValueIdentifier: PantosValue.name) else {
+                    return .failure(.invalidMasterPlaylistError(errorText: "GroupId and Name are required for media tags"))
+            }
+            guard let uri: String = mediaTag.value(forValueIdentifier: PantosValue.uri) else {
+                // if we do not have a uri this is not a seperately available stream and we can skip it
+                if type == .Video || type == .Audio {
+                    // we still record it so we can avoid a potential lookup when we parse streaminf tags later
+                    nonStreamMediaGroupInfo.append(NonStreamMediaGroupInfo(groupId: groupId,
+                                                                           name: name,
+                                                                           language: mediaTag.value(forValueIdentifier: PantosValue.language),
+                                                                           type: type))
+                }
+                continue
+            }
+            switch type.type {
+            case .Audio:
+                streams.append(.audioMediaStream(mediaIndex: mediaIndex,
+                                                 uri: uri,
+                                                 groupId: groupId,
+                                                 name: name,
+                                                 language: mediaTag.value(forValueIdentifier: PantosValue.language),
+                                                 associatedLanguage: mediaTag.value(forValueIdentifier: PantosValue.assocLanguage)))
+            case .Video:
+                streams.append(.videoMediaStream(mediaIndex: mediaIndex,
+                                                 uri: uri,
+                                                 groupId: groupId,
+                                                 name: name,
+                                                 language: mediaTag.value(forValueIdentifier: PantosValue.language),
+                                                 associatedLanguage: mediaTag.value(forValueIdentifier: PantosValue.assocLanguage)))
+            case .Subtitles:
+                streams.append(.subtitlesMediaStream(mediaIndex: mediaIndex,
+                                                     uri: uri,
+                                                     groupId: groupId))
+            default:
+                break
+            }
+        }
+        
+        // parse the streamInf streams
+        let streamInfIndices = tags.indices.filter { tags[$0].tagDescriptor == PantosTag.EXT_X_STREAM_INF }
+        for streamInfIndex in streamInfIndices {
+            guard let streamInfTag = tags[safe: streamInfIndex] else {
+                assertionFailure("It's odd that the index we just calculated for the streaminf tag is no longer valid")
+                return .failure(.internalIndexError)
+            }
+            let locationTagIndex = streamInfIndex + 1
+            guard
+                let locationTag = tags[safe: locationTagIndex],
+                locationTag.tagDescriptor == PantosTag.Location else {
+                    return .failure(.invalidMasterPlaylistError(errorText: "Location tags must immediately follow streamInf tags"))
+            }
+            guard let bandwidth: Int = streamInfTag.value(forValueIdentifier: PantosValue.bandwidthBPS) else {
+                return .failure(.invalidMasterPlaylistError(errorText: "Bandwidth is required for streamInf tags"))
+            }
+            let uri = locationTag.tagData.stringValue()
+            
+            // make the complicated decision about if we are muxed or not
+            let streamInfContainsAudio = containsMediaInfo(forStreamContents: .audio,
+                                                           inStreamInfTag: streamInfTag,
+                                                           withStreamInfLocationUrl: uri,
+                                                           withStreams: streams,
+                                                           withNonStreamMediaGroupInfo: nonStreamMediaGroupInfo)
+            
+            let streamInfContainsVideo = containsMediaInfo(forStreamContents: .video,
+                                                           inStreamInfTag: streamInfTag,
+                                                           withStreamInfLocationUrl: uri,
+                                                           withStreams: streams,
+                                                           withNonStreamMediaGroupInfo: nonStreamMediaGroupInfo)
+            
+            let streamType: StreamType
+            switch (streamInfContainsAudio, streamInfContainsVideo) {
+            case (true, true):
+                streamType = .muxed
+                break
+            case (true, false):
+                streamType = .demuxedAudio
+                break
+            case (false, true):
+                streamType = .demuxedVideo
+                break
+            case (false, false):
+                return .failure(.invalidMasterPlaylistError(errorText: "StreamInf tag was found to have neither audio nor video streams"))
+            }
+            
+            streams.append(.stream(streamInfIndex: streamInfIndex,
+                                   locationIndex: locationTagIndex,
+                                   uri: uri,
+                                   audioGroupId: streamInfTag.value(forValueIdentifier: PantosValue.audioGroup),
+                                   videoGroupId: streamInfTag.value(forValueIdentifier: PantosValue.videoGroup),
+                                   captionsGroupId: streamInfTag.value(forValueIdentifier: PantosValue.closedCaptionsGroup),
+                                   streamType: streamType,
+                                   bandwidth: bandwidth,
+                                   resolution: streamInfTag.value(forValueIdentifier: PantosValue.resolution)))
+        }
+        
+        return .success(PlaylistStreamSummary(streams: streams))
+    }
+}
+
+/// An object that summarizes all the independantly addressable streams in a master playlist.
+public struct PlaylistStreamSummary {
+    
+    /// An array of `PlaylistStream` enum values: one for each stream in the playlist.
+    public let streams: [PlaylistStream]
+    
+    // An `OptionSet` summary of the muxed/demuxed status of the entire playlist.
+    public let muxedStatus: PlaylistMuxedStatus
+    
+    fileprivate init(streams: [PlaylistStream]) {
+        self.streams = streams
+        var status = PlaylistMuxedStatus(rawValue: 0)
+        for stream in streams {
+            if let streamType = stream.streamType {
+                switch streamType {
+                case .muxed:
+                    status.insert(.containsMuxedAudioVideo)
+                case .demuxedVideo:
+                    status.insert(.containsDemuxedVideo)
+                case .demuxedAudio:
+                    status.insert(.containsDemuxedAudio)
+                }
+            }
+        }
+        self.muxedStatus = status
+    }
+}
+
+/**
+ A description of all the possible individually addressable streams in a HLS asset.
+ 
+ It's probably worth noting that closed captions is not present. As far as the HLS specification
+ is concerned, closed captions are only delivered through the media segments. They cannot be
+ seperate streams.
+ */
+public enum PlaylistStream {
+    /**
+     A stream found in a #EXT-X-STREAM-INF tag.
+     
+     # Enum associated values
+     
+     - `streamInfIndex`: An index into the `MasterPlaylist` tag array for the matching stream inf tag.
+     - `locationIndex`: An index into the `MasterPlaylist` tag array for the matching location/uri tag.
+     - `uri`: The uri of this stream.
+     - `audioGroupId`: The group id reference for any external audio streams, if available.
+     - `videoGroupId`: The group id reference for any external video streams, if available.
+     - `captionsGroupId`: The group id reference for any external closed captions streams, if available.
+     - `streamType`: The calculated `StreamType` for this stream.
+     - `bandwidth`: The bandwidth for the stream.
+     - `resolution`: The resolution for this stream if available.
+     */
+    case stream(streamInfIndex: Int, locationIndex: Int, uri: String, audioGroupId: String?, videoGroupId: String?, captionsGroupId: String?, streamType: StreamType, bandwidth: Int, resolution: ResolutionValueType?)
+    /**
+     An audio stream found in a #EXT-X-MEDIA tag.
+     
+     # Enum associated values
+     
+     - `mediaIndex`: An index into the `MasterPlaylist` tag array for the matching media tag.
+     - `uri`: The uri of this stream.
+     - `groupId`: The group id reference for this stream to match with a streamInf tag.
+     - `name`: The name given to this stream.
+     - `language`: The language of this stream.
+     - `associatedLanguage`: The associated language for this stream (see the HLS/Pantos spec for details)
+     */
+    case audioMediaStream(mediaIndex: Int, uri: String, groupId: String, name: String, language: String?, associatedLanguage: String?)
+    /**
+     A video stream found in a #EXT-X-MEDIA tag.
+     
+     # Enum associated values
+     
+     - `mediaIndex`: An index into the `MasterPlaylist` tag array for the matching media tag.
+     - `uri`: The uri of this stream.
+     - `groupId`: The group id reference for this stream to match with a streamInf tag.
+     - `name`: The name given to this stream.
+     - `language`: The language of this stream.
+     - `associatedLanguage`: The associated language for this stream (see the HLS/Pantos spec for details)
+     */
+    case videoMediaStream(mediaIndex: Int, uri: String, groupId: String, name: String, language: String?, associatedLanguage: String?)
+    /**
+     A subtitles stream found in a #EXT-X-MEDIA tag.
+     
+     # Enum associated values
+     
+     - `mediaIndex`: An index into the `MasterPlaylist` tag array for the matching media tag.
+     - `uri`: The uri of this stream.
+     - `groupId`: The group id reference for this stream to match with a streamInf tag.
+     */
+    case subtitlesMediaStream(mediaIndex: Int, uri: String, groupId: String)
+    /**
+     A stream found in a #EXT-X-I-FRAME-STREAM-INF tag.
+     
+     # Enum associated values
+     
+     - `iFrameStreamInfIndex`: An index into the `MasterPlaylist` tag array for the matching iFrameStreamInf tag.
+     - `uri`: The uri of this stream.
+     */
+    case iFrameStream(iFrameStreamInfIndex: Int, uri: String)
+}
+
+public extension PlaylistStream {
+    /// Returns the uri of the stream
+    var uri: String {
+        switch self {
+        case .audioMediaStream(_, let uri, _, _, _, _):
+            return uri
+        case .videoMediaStream(_, let uri, _, _, _, _):
+            return uri
+        case .subtitlesMediaStream(_, let uri, _):
+            return uri
+        case .iFrameStream(_, let uri):
+            return uri
+        case .stream(_, _, let uri, _, _, _, _, _, _):
+            return uri
+        }
+    }
+    // returns the `StreamType` for this stream if applicable.
+    var streamType: StreamType? {
+        switch self {
+        case .audioMediaStream(_):
+            return .demuxedAudio
+        case .videoMediaStream(_):
+            return .demuxedVideo
+        case .subtitlesMediaStream(_):
+            return nil
+        case .iFrameStream(_):
+            return nil
+        case .stream(_, _, _, _, _, _, let streamType, _, _):
+            return streamType
+        }
+    }
+}
+
+/// A description of the type of stream for audio/video streams
+public enum StreamType {
+    /// Audio and Video are muxed together into one stream
+    case muxed
+    /// A standalone video stream
+    case demuxedVideo
+    /// A standalone audio stream
+    case demuxedAudio
+}
+
+/// A summary of the muxed/demuxed audio/video content in a HLS asset
+public struct PlaylistMuxedStatus: OptionSet {
+    public let rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    /// Flag represents the presence of at least one muxed audio/video stream
+    public static let containsMuxedAudioVideo   = PlaylistMuxedStatus(rawValue: 1 << 1)
+    /// Flag represents the presence of at least one demuxed audio stream
+    public static let containsDemuxedAudio      = PlaylistMuxedStatus(rawValue: 1 << 2)
+    /// Flag represents the presence of at least one demuxed video stream
+    public static let containsDemuxedVideo      = PlaylistMuxedStatus(rawValue: 1 << 3)
+}
+
+/// An `Error` enum describing possible errors in producing a summary of the streams in a playlist
+public enum StreamSummaryError: Error {
+    /// Unable to process the summary due to a problem with the master HLS. The problem is described in the `errorText`
+    case invalidMasterPlaylistError(errorText: String)
+    /// An internal indexing error was found. This probably means the master playlist was edited while the summary was being constructed.
+    case internalIndexError
+}
+
+// MARK: Private objects and code
+
+fileprivate extension PlaylistStream {
+    func isAudioMediaStream(withMediaGroupId mediaGroupId: String) -> Bool {
+        switch self {
+        case .audioMediaStream(_, _, let groupId, _, _, _):
+            return groupId == mediaGroupId
+        default:
+            return false
+        }
+    }
+    func isVideoMediaStream(withMediaGroupId mediaGroupId: String) -> Bool {
+        switch self {
+        case .videoMediaStream(_, _, let groupId, _, _, _):
+            return groupId == mediaGroupId
+        default:
+            return false
+        }
+    }
+}
+
+fileprivate struct NonStreamMediaGroupInfo {
+    let groupId: String
+    let name: String
+    let language: String?
+    let type: MediaType
+}
+
+extension Collection where Iterator.Element == NonStreamMediaGroupInfo {
+    fileprivate func getNonStreams(matchingStreamContentsQuery streamContentsQuery: StreamContentsQuery,
+                                   withMediaGroupId mediaGroupId: String) -> [NonStreamMediaGroupInfo] {
+        switch streamContentsQuery {
+        case .audio:
+            return self.filter { $0.type == .Audio && $0.groupId == mediaGroupId }
+        case .video:
+            return self.filter { $0.type == .Video && $0.groupId == mediaGroupId }
+        }
+    }
+}
+
+extension Collection where Iterator.Element == PlaylistStream {
+    fileprivate func getStreams(matchingStreamContentsQuery streamContentsQuery: StreamContentsQuery,
+                                withMediaGroupId mediaGroupId: String) -> [PlaylistStream] {
+        switch streamContentsQuery {
+        case .audio:
+            return self.filter { $0.isAudioMediaStream(withMediaGroupId: mediaGroupId) }
+        case .video:
+            return self.filter { $0.isVideoMediaStream(withMediaGroupId: mediaGroupId) }
+        }
+    }
+}
+
+fileprivate func containsMediaInfo(forStreamContents streamContentsQuery: StreamContentsQuery,
+                                   inStreamInfTag streamInfTag: PlaylistTag,
+                                   withStreamInfLocationUrl streamInfUrl: String,
+                                   withStreams streams: [PlaylistStream],
+                                   withNonStreamMediaGroupInfo nonStreamMediaGroupInfo: [NonStreamMediaGroupInfo]) -> Bool {
+    
+    let mediaValueIdentifier: PantosValue
+    
+    switch streamContentsQuery {
+    case .audio:
+        mediaValueIdentifier = PantosValue.audioGroup
+    case .video:
+        mediaValueIdentifier = PantosValue.videoGroup
+    }
+    
+    if let mediaGroupId: String = streamInfTag.value(forValueIdentifier: mediaValueIdentifier) {
+        let mediaStreamsForGroup = streams.getStreams(matchingStreamContentsQuery: streamContentsQuery,
+                                                      withMediaGroupId: mediaGroupId)
+        let nonMediaStreamsForGroup = nonStreamMediaGroupInfo.getNonStreams(matchingStreamContentsQuery: streamContentsQuery,
+                                                                            withMediaGroupId: mediaGroupId)
+        if mediaStreamsForGroup.isEmpty {
+            // we have no media streams.
+            // let's check the codecs to be certain
+            return containsMediaInfoFallbackToCodecs(forStreamContents: streamContentsQuery, inStreamInfTag: streamInfTag)
+        }
+        else if !nonMediaStreamsForGroup.isEmpty {
+            // we have some media streams, but we also have some MEDIA tags with no media streams, so we must contain media
+            return true
+        }
+        else {
+            // There is an odd use case to handle here.
+            // Let's say we have a fully demuxed audio/video HLS asset, AND we want to deliver a very low bandwidth
+            // audio-only rendition. (i.e. the same audio we are using for our higher bandwidth video+audio streams)
+            // How do we express this?
+            // It turns out that it's playable HLS to have *the same stream* in a #EXT-X-STREAMINF tag and a #EXT-X-MEDIA
+            // tag. (playable by AVFoundation at least ... the spec is not clear on this subject).
+            // We check for that situation here.
+            
+            for mediaStream in mediaStreamsForGroup {
+                if mediaStream.uri == streamInfUrl {
+                    // This EXT-X-STREAMINF tag stream contains media that matches with a media stream. We must contain that media type.
+                    return true
+                }
+            }
+            
+            // all other cases: our streamInf media stream has no media of the type we are looking for
+            return false
+        }
+    }
+    
+    // we'd get here if we did not have a media group id
+    // let's check the codecs to be certain
+    return containsMediaInfoFallbackToCodecs(forStreamContents: streamContentsQuery, inStreamInfTag: streamInfTag)
+}
+
+fileprivate func containsMediaInfoFallbackToCodecs(forStreamContents streamContentsQuery: StreamContentsQuery,
+                                                   inStreamInfTag streamInfTag: PlaylistTag) -> Bool {
+    if let codecs: CodecValueTypeArray = streamInfTag.codecs() {
+        switch streamContentsQuery {
+        case .audio:
+            return codecs.containsAudio()
+        case .video:
+            return codecs.containsVideo()
+        }
+    }
+    
+    // without codecs data, we assume we do contain this media type...
+    return true
+}
+
+fileprivate enum StreamContentsQuery {
+    case video
+    case audio
+}
+

--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
@@ -27,7 +27,7 @@ extension PlaylistCore where PT == MasterPlaylistType {
      It's worth noting that this function captures the state of the playlist when it's called. The
      `PlaylistStreamSummary` object that is returned will not update if the master playlist is edited.
      
-     This function is also not thread safe. Please esnure that no other threads are editing this master playlist
+     This function is also not thread safe. Please ensure that no other threads are editing this master playlist
      while executing.
      
      - returns: A `Result` object with either a `PlaylistStreamSummary` for success or a `StreamSummaryError` for failure.

--- a/mambaSharedFramework/ValueTypes.swift
+++ b/mambaSharedFramework/ValueTypes.swift
@@ -102,6 +102,22 @@ public func ==(lhs: MediaType, rhs: MediaType) -> Bool {
     return lhs.type == rhs.type
 }
 
+public func ==(lhs: MediaType, rhs: MediaType.Media) -> Bool {
+    return lhs.type == rhs
+}
+
+public func ==(lhs: MediaType.Media, rhs: MediaType) -> Bool {
+    return lhs == rhs.type
+}
+
+public func !=(lhs: MediaType, rhs: MediaType.Media) -> Bool {
+    return !(lhs == rhs)
+}
+
+public func !=(lhs: MediaType.Media, rhs: MediaType) -> Bool {
+    return !(lhs == rhs)
+}
+
 /// Represents an encryption method
 ///
 /// Can be initialized with a string "NONE" or "AES-128" or "SAMPLE-AES" for a valid value

--- a/mambaTests/MasterPlaylistStreamSummaryTests.swift
+++ b/mambaTests/MasterPlaylistStreamSummaryTests.swift
@@ -1,0 +1,776 @@
+//
+//  MasterPlaylistStreamSummaryTests.swift
+//  mamba
+//
+//  Created by David Coufal on 6/12/19.
+//  Copyright © 2019 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import XCTest
+import mamba
+
+class MasterPlaylistStreamSummaryTests: XCTestCase {
+    
+    func testDemuxedMaster() {
+        let master = parseMasterPlaylist(inString: demuxedMasterSample)
+        
+        let result = master.calculateStreamSummary()
+        let summary: PlaylistStreamSummary
+        switch result {
+        case .success(let summ):
+            summary = summ
+        case .failure(let error):
+            XCTFail("calculateStreamSummary Failed with error \(error)")
+            return
+        }
+        
+        var iFrameCount = 0
+        var audioCount = 0
+        var streamInfCount = 0
+        
+        for stream in summary.streams {
+            switch stream {
+            case .iFrameStream(let iFrameStreamInfIndex, let uri):
+                iFrameCount += 1
+                
+                switch iFrameStreamInfIndex {
+                case 17:
+                    XCTAssertEqual(uri, "iframe-180p-video-low.m3u8")
+                    break
+                case 18:
+                    XCTAssertEqual(uri, "iframe-180p-video-high.m3u8")
+                    break
+                case 19:
+                    XCTAssertEqual(uri, "iframe-288p-video.m3u8")
+                    break
+                case 20:
+                    XCTAssertEqual(uri, "iframe-360p-video.m3u8")
+                    break
+                case 21:
+                    XCTAssertEqual(uri, "iframe-432p-video.m3u8")
+                    break
+                case 22:
+                    XCTAssertEqual(uri, "iframe-720p-video-low.m3u8")
+                    break
+                case 23:
+                    XCTAssertEqual(uri, "iframe-720p-video-high.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected iFrameStreamInfIndex: \(iFrameStreamInfIndex)")
+                }
+                break
+            case .audioMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
+                audioCount += 1
+                
+                switch mediaIndex {
+                case 1:
+                    XCTAssertEqual(groupId, "low")
+                    XCTAssertEqual(name, "English")
+                    XCTAssertEqual(language, "en")
+                    XCTAssertEqual(associatedLanguage, nil)
+                    XCTAssertEqual(uri, "low-bandwidth-audio.m3u8")
+                    break
+                case 2:
+                    XCTAssertEqual(groupId, "high")
+                    XCTAssertEqual(name, "English")
+                    XCTAssertEqual(language, "en")
+                    XCTAssertEqual(associatedLanguage, nil)
+                    XCTAssertEqual(uri, "high-bandwidth-audio.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected mediaIndex: \(mediaIndex)")
+                }
+                break
+            case .videoMediaStream(_):
+                XCTFail("Unexpected video stream")
+            case .subtitlesMediaStream(_):
+                XCTFail("Unexpected subtitles stream")
+            case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
+                streamInfCount += 1
+                
+                XCTAssertEqual(streamInfIndex + 1, locationIndex)
+                
+                switch streamInfIndex {
+                case 3:
+                    XCTAssertEqual(audioGroupId, "low")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 464000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 320, height: 180))
+                    XCTAssertEqual(uri, "180p-video-low.m3u8")
+                    break
+                case 5:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 664400)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 320, height: 180))
+                    XCTAssertEqual(uri, "180p-video-high.m3u8")
+                    break
+                case 7:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 1242000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 512, height: 288))
+                    XCTAssertEqual(uri, "288p-video.m3u8")
+                    break
+                case 9:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 1767200)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 640, height: 360))
+                    XCTAssertEqual(uri, "360p-video.m3u8")
+                    break
+                case 11:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 2082000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 768, height: 432))
+                    XCTAssertEqual(uri, "432p-video.m3u8")
+                    break
+                case 13:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 2292000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-video-low.m3u8")
+                    break
+                case 15:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 3922400)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-video-high.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected streamInfIndex: \(streamInfIndex)")
+                }
+            }
+        }
+        
+        XCTAssertEqual(iFrameCount, 7)
+        XCTAssertEqual(audioCount, 2)
+        XCTAssertEqual(streamInfCount, 7)
+        
+        XCTAssertTrue(summary.muxedStatus.contains(.containsDemuxedAudio))
+        XCTAssertTrue(summary.muxedStatus.contains(.containsDemuxedVideo))
+        XCTAssertFalse(summary.muxedStatus.contains(.containsMuxedAudioVideo))
+    }
+    
+    func testMuxedMasterWithSAP() {
+        let master = parseMasterPlaylist(inString: muxedMasterSampleWithSAP)
+        
+        let result = master.calculateStreamSummary()
+        let summary: PlaylistStreamSummary
+        switch result {
+        case .success(let summ):
+            summary = summ
+        case .failure(let error):
+            XCTFail("calculateStreamSummary Failed with error \(error)")
+            return
+        }
+        
+        var iFrameCount = 0
+        var audioCount = 0
+        var streamInfCount = 0
+        
+        for stream in summary.streams {
+            switch stream {
+            case .iFrameStream(let iFrameStreamInfIndex, let uri):
+                iFrameCount += 1
+                
+                switch iFrameStreamInfIndex {
+                case 20:
+                    XCTAssertEqual(uri, "iframe-180p-video-low.m3u8")
+                    break
+                case 21:
+                    XCTAssertEqual(uri, "iframe-180p-video-high.m3u8")
+                    break
+                case 22:
+                    XCTAssertEqual(uri, "iframe-288p-video.m3u8")
+                    break
+                case 23:
+                    XCTAssertEqual(uri, "iframe-360p-video.m3u8")
+                    break
+                case 24:
+                    XCTAssertEqual(uri, "iframe-432p-video.m3u8")
+                    break
+                case 25:
+                    XCTAssertEqual(uri, "iframe-720p-video-low.m3u8")
+                    break
+                case 26:
+                    XCTAssertEqual(uri, "iframe-720p-video-high.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected iFrameStreamInfIndex: \(iFrameStreamInfIndex)")
+                }
+            case .audioMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
+                audioCount += 1
+                
+                switch mediaIndex {
+                case 2:
+                    XCTAssertEqual(groupId, "low")
+                    XCTAssertEqual(name, "Spanish")
+                    XCTAssertEqual(language, "es")
+                    XCTAssertEqual(associatedLanguage, nil)
+                    XCTAssertEqual(uri, "low-bandwidth-es-audio.m3u8")
+                    break
+                case 3:
+                    XCTAssertEqual(groupId, "high")
+                    XCTAssertEqual(name, "Spanish")
+                    XCTAssertEqual(language, "es")
+                    XCTAssertEqual(associatedLanguage, nil)
+                    XCTAssertEqual(uri, "high-bandwidth-es-audio.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected mediaIndex: \(mediaIndex)")
+                }
+            case .videoMediaStream(_):
+                XCTFail("Unexpected video stream")
+            case .subtitlesMediaStream(_):
+                XCTFail("Unexpected subtitles stream")
+            case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
+                streamInfCount += 1
+                
+                XCTAssertEqual(streamInfIndex + 1, locationIndex)
+                
+                switch streamInfIndex {
+                case 4:
+                    XCTAssertEqual(audioGroupId, "low")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 560400)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 320, height: 180))
+                    XCTAssertEqual(uri, "180p-muxed-low.m3u8")
+                    break
+                case 6:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 788800)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 320, height: 180))
+                    XCTAssertEqual(uri, "180p-muxed-high.m3u8")
+                    break
+                case 8:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 1072000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 512, height: 288))
+                    XCTAssertEqual(uri, "288p-muxed.m3u8")
+                    break
+                case 10:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 1426400)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 640, height: 360))
+                    XCTAssertEqual(uri, "360p-muxed.m3u8")
+                    break
+                case 12:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 2064400)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 768, height: 432))
+                    XCTAssertEqual(uri, "432p-muxed.m3u8")
+                    break
+                case 14:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 3190400)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-muxed-low.m3u8")
+                    break
+                case 16:
+                    XCTAssertEqual(audioGroupId, "high")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 4529600)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-muxed-high.m3u8")
+                    break
+                case 18:
+                    XCTAssertEqual(audioGroupId, "low")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.demuxedAudio)
+                    XCTAssertEqual(bandwidth, 104000)
+                    XCTAssertEqual(resolution, nil)
+                    XCTAssertEqual(uri, "low-bandwidth-audio.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected streamInfIndex: \(streamInfIndex)")
+                }
+            }
+        }
+        
+        XCTAssertEqual(iFrameCount, 7)
+        XCTAssertEqual(audioCount, 2)
+        XCTAssertEqual(streamInfCount, 8)
+        
+        XCTAssertTrue(summary.muxedStatus.contains(.containsDemuxedAudio))
+        XCTAssertFalse(summary.muxedStatus.contains(.containsDemuxedVideo))
+        XCTAssertTrue(summary.muxedStatus.contains(.containsMuxedAudioVideo))
+    }
+    
+    func testLowBandwidthAudioOnlyDemuxedMaster() {
+        let master = parseMasterPlaylist(inString: lowBandwidthAudioOnlyDemuxedSample)
+        
+        let result = master.calculateStreamSummary()
+        let summary: PlaylistStreamSummary
+        switch result {
+        case .success(let summ):
+            summary = summ
+        case .failure(let error):
+            XCTFail("calculateStreamSummary Failed with error \(error)")
+            return
+        }
+        
+        var audioCount = 0
+        var streamInfCount = 0
+        
+        for stream in summary.streams {
+            switch stream {
+            case .iFrameStream(_):
+                XCTFail("Unexpected iframe stream")
+            case .audioMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
+                audioCount += 1
+                
+                switch mediaIndex {
+                case 1:
+                    XCTAssertEqual(groupId, "audio")
+                    XCTAssertEqual(name, "audio 0")
+                    XCTAssertEqual(language, nil)
+                    XCTAssertEqual(associatedLanguage, nil)
+                    XCTAssertEqual(uri, "audio.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected mediaIndex: \(mediaIndex)")
+                }
+            case .videoMediaStream(_):
+                XCTFail("Unexpected video stream")
+            case .subtitlesMediaStream(_):
+                XCTFail("Unexpected subtitles stream")
+            case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
+                streamInfCount += 1
+                
+                XCTAssertEqual(streamInfIndex + 1, locationIndex)
+                
+                switch streamInfIndex {
+                case 2:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedAudio)
+                    XCTAssertEqual(bandwidth, 104000)
+                    XCTAssertEqual(resolution, nil)
+                    XCTAssertEqual(uri, "audio.m3u8")
+                    break
+                case 4:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 312000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 320, height: 180))
+                    XCTAssertEqual(uri, "180p-video-low.m3u8")
+                    break
+                case 6:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 416000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 320, height: 180))
+                    XCTAssertEqual(uri, "180p-video-high.m3u8")
+                    break
+                case 8:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 620000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 512, height: 288))
+                    XCTAssertEqual(uri, "288p-video.m3u8")
+                    break
+                case 10:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 874000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 640, height: 360))
+                    XCTAssertEqual(uri, "360p-video.m3u8")
+                    break
+                case 12:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 1378000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 768, height: 432))
+                    XCTAssertEqual(uri, "432p-video.m3u8")
+                    break
+                case 14:
+                    XCTAssertEqual(audioGroupId, "audio")
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, "NONE")
+                    XCTAssertEqual(streamType, StreamType.demuxedVideo)
+                    XCTAssertEqual(bandwidth, 2230000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-video.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected streamInfIndex: \(streamInfIndex)")
+                }
+            }
+        }
+        
+        
+        XCTAssertEqual(audioCount, 1)
+        XCTAssertEqual(streamInfCount, 7)
+        
+        XCTAssertTrue(summary.muxedStatus.contains(.containsDemuxedAudio))
+        XCTAssertTrue(summary.muxedStatus.contains(.containsDemuxedVideo))
+        XCTAssertFalse(summary.muxedStatus.contains(.containsMuxedAudioVideo))
+    }
+    
+    func testAltVideoAltSubtitlesMuxed() {
+        let master = parseMasterPlaylist(inString: altVideoAltSubtitlesMuxedSample)
+        
+        let result = master.calculateStreamSummary()
+        let summary: PlaylistStreamSummary
+        switch result {
+        case .success(let summ):
+            summary = summ
+        case .failure(let error):
+            XCTFail("calculateStreamSummary Failed with error \(error)")
+            return
+        }
+        
+        var videoCount = 0
+        var subtitlesCount = 0
+        var streamInfCount = 0
+        
+        for stream in summary.streams {
+            switch stream {
+            case .iFrameStream(_):
+                XCTFail("Unexpected iframe stream")
+            case .audioMediaStream(_):
+                XCTFail("Unexpected audio stream")
+            case .videoMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
+                videoCount += 1
+                
+                switch mediaIndex {
+                case 1:
+                    XCTAssertEqual(groupId, "video")
+                    XCTAssertEqual(name, "alt video")
+                    XCTAssertEqual(language, nil)
+                    XCTAssertEqual(associatedLanguage, nil)
+                    XCTAssertEqual(uri, "alt_video.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected mediaIndex: \(mediaIndex)")
+                }
+            case .subtitlesMediaStream(let mediaIndex, let uri, let groupId):
+                subtitlesCount += 1
+                
+                switch mediaIndex {
+                case 3:
+                    XCTAssertEqual(groupId, "subs")
+                    XCTAssertEqual(uri, "subtitles.subs")
+                    break
+                default:
+                    XCTFail("Unexpected mediaIndex: \(mediaIndex)")
+                }
+            case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
+                streamInfCount += 1
+                
+                XCTAssertEqual(streamInfIndex + 1, locationIndex)
+                
+                switch streamInfIndex {
+                case 4:
+                    XCTAssertEqual(audioGroupId, nil)
+                    XCTAssertEqual(videoGroupId, "video")
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 500000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 512, height: 288))
+                    XCTAssertEqual(uri, "288p-muxed.m3u8")
+                    break
+                case 6:
+                    XCTAssertEqual(audioGroupId, nil)
+                    XCTAssertEqual(videoGroupId, "video")
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 1300000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 768, height: 432))
+                    XCTAssertEqual(uri, "432p-muxed.m3u8")
+                    break
+                case 8:
+                    XCTAssertEqual(audioGroupId, nil)
+                    XCTAssertEqual(videoGroupId, "video")
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 2200000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-muxed.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected streamInfIndex: \(streamInfIndex)")
+                }
+            }
+        }
+        
+        XCTAssertEqual(videoCount, 1)
+        XCTAssertEqual(subtitlesCount, 1)
+        XCTAssertEqual(streamInfCount, 3)
+        
+        XCTAssertFalse(summary.muxedStatus.contains(.containsDemuxedAudio))
+        XCTAssertTrue(summary.muxedStatus.contains(.containsDemuxedVideo))
+        XCTAssertTrue(summary.muxedStatus.contains(.containsMuxedAudioVideo))
+    }
+    
+    func testMuxed() {
+        let master = parseMasterPlaylist(inString: muxedSample)
+        
+        let result = master.calculateStreamSummary()
+        let summary: PlaylistStreamSummary
+        switch result {
+        case .success(let summ):
+            summary = summ
+        case .failure(let error):
+            XCTFail("calculateStreamSummary Failed with error \(error)")
+            return
+        }
+        
+        var streamInfCount = 0
+        
+        for stream in summary.streams {
+            switch stream {
+            case .iFrameStream(_):
+                XCTFail("Unexpected iframe stream")
+            case .audioMediaStream(_):
+                XCTFail("Unexpected audio stream")
+            case .videoMediaStream(_):
+                XCTFail("Unexpected video stream")
+            case .subtitlesMediaStream(_):
+                XCTFail("Unexpected subtitles stream")
+            case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
+                streamInfCount += 1
+                
+                XCTAssertEqual(streamInfIndex + 1, locationIndex)
+                
+                switch streamInfIndex {
+                case 0:
+                    XCTAssertEqual(audioGroupId, nil)
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 500000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 512, height: 288))
+                    XCTAssertEqual(uri, "288p-muxed.m3u8")
+                    break
+                case 2:
+                    XCTAssertEqual(audioGroupId, nil)
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 1300000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 768, height: 432))
+                    XCTAssertEqual(uri, "432p-muxed.m3u8")
+                    break
+                case 4:
+                    XCTAssertEqual(audioGroupId, nil)
+                    XCTAssertEqual(videoGroupId, nil)
+                    XCTAssertEqual(captionsGroupId, nil)
+                    XCTAssertEqual(streamType, StreamType.muxed)
+                    XCTAssertEqual(bandwidth, 2200000)
+                    XCTAssertEqual(resolution, ResolutionValueType(width: 1280, height: 720))
+                    XCTAssertEqual(uri, "720p-muxed.m3u8")
+                    break
+                default:
+                    XCTFail("Unexpected streamInfIndex: \(streamInfIndex)")
+                }
+            }
+        }
+        
+        XCTAssertEqual(streamInfCount, 3)
+        
+        XCTAssertFalse(summary.muxedStatus.contains(.containsDemuxedAudio))
+        XCTAssertFalse(summary.muxedStatus.contains(.containsDemuxedVideo))
+        XCTAssertTrue(summary.muxedStatus.contains(.containsMuxedAudioVideo))
+    }
+    
+    func testErrors() {
+        let master = parseMasterPlaylist(inString: brokenSample)
+        
+        let result = master.calculateStreamSummary()
+        switch result {
+        case .success(_):
+            XCTFail("Not expecting a success")
+        case .failure(let error):
+            switch error {
+            case .invalidMasterPlaylistError(let errorText):
+                XCTAssert(errorText.contains("Location") && errorText.contains("streamInf"), "Expecting this error to be about location tags")
+            case .internalIndexError:
+                XCTFail("Not expecting this error")
+            }
+            return
+        }
+    }
+    
+}
+
+fileprivate let demuxedMasterSample = """
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="low",NAME="English",LANGUAGE="en",URI="low-bandwidth-audio.m3u8",DEFAULT=YES,AUTOSELECT=YES
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="high",NAME="English",LANGUAGE="en",URI="high-bandwidth-audio.m3u8",DEFAULT=YES,AUTOSELECT=YES
+
+#EXT-X-STREAM-INF:BANDWIDTH=464000,AUDIO="low",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=320x180
+180p-video-low.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=664400,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=320x180
+180p-video-high.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1242000,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=512x288
+288p-video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1767200,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=640x360
+360p-video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2082000,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=768x432
+432p-video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2292000,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.640029,mp4a.40.5",RESOLUTION=1280x720
+720p-video-low.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3922400,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.640029,mp4a.40.5",RESOLUTION=1280x720
+720p-video-high.m3u8
+
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=360000,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=320x180,URI="iframe-180p-video-low.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=517200,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=320x180,URI="iframe-180p-video-high.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1094800,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=512x288,URI="iframe-288p-video.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1620000,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=640x360,URI="iframe-360p-video.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1934800,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=768x432,URI="iframe-432p-video.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=2144800,PROGRAM-ID=1,CODECS="avc1.640029",RESOLUTION=1280x720,URI="iframe-720p-video-low.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=3775200,PROGRAM-ID=1,CODECS="avc1.640029",RESOLUTION=1280x720,URI="iframe-720p-video-high.m3u8"
+"""
+
+fileprivate let muxedMasterSampleWithSAP = """
+#EXTM3U
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="low",NAME="English",LANGUAGE="en",DEFAULT=YES,AUTOSELECT=YES
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="high",NAME="English",LANGUAGE="en",DEFAULT=YES,AUTOSELECT=YES
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="low",NAME="Spanish",LANGUAGE="es",URI="low-bandwidth-es-audio.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="high",NAME="Spanish",LANGUAGE="es",URI="high-bandwidth-es-audio.m3u8"
+
+#EXT-X-STREAM-INF:BANDWIDTH=560400,AUDIO="low",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=320x180
+180p-muxed-low.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=788800,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=320x180
+180p-muxed-high.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1072000,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=512x288
+288p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1426400,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=640x360
+360p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2064400,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d401f,mp4a.40.5",RESOLUTION=768x432
+432p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3190400,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.4d4020,mp4a.40.5",RESOLUTION=1280x720
+720p-muxed-low.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=4529600,AUDIO="high",PROGRAM-ID=1,CODECS="avc1.640029,mp4a.40.5",RESOLUTION=1280x720
+720p-muxed-high.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=104000,AUDIO="low",PROGRAM-ID=1,CODECS="mp4a.40.5"
+low-bandwidth-audio.m3u8
+
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=360000,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=320x180,URI="iframe-180p-video-low.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=517200,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=320x180,URI="iframe-180p-video-high.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1094800,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=512x288,URI="iframe-288p-video.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1620000,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=640x360,URI="iframe-360p-video.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1934800,PROGRAM-ID=1,CODECS="avc1.4d401f",RESOLUTION=768x432,URI="iframe-432p-video.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=2144800,PROGRAM-ID=1,CODECS="avc1.640029",RESOLUTION=1280x720,URI="iframe-720p-video-low.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=3775200,PROGRAM-ID=1,CODECS="avc1.640029",RESOLUTION=1280x720,URI="iframe-720p-video-high.m3u8"
+"""
+
+/// This kind of stream is a little exotic (check out the first #EXT-X-STREAM-INF stream and the #EXT-X-MEDIA stream, they are the same!).
+/// But it plays so we should handle it.
+fileprivate let lowBandwidthAudioOnlyDemuxedSample = """
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="audio 0",AUTOSELECT=YES,DEFAULT=YES,URI="audio.m3u8"
+
+#EXT-X-STREAM-INF:BANDWIDTH=104000,AVERAGE-BANDWIDTH=99000,CLOSED-CAPTIONS=NONE,CODECS="mp4a.40.2",AUDIO="audio"
+audio.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=312000,AVERAGE-BANDWIDTH=264000,RESOLUTION=320x180,CLOSED-CAPTIONS=NONE,CODECS="avc1.4d401f,mp4a.40.2",AUDIO="audio"
+180p-video-low.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=416000,AVERAGE-BANDWIDTH=339000,RESOLUTION=320x180,CLOSED-CAPTIONS=NONE,CODECS="avc1.4d401f,mp4a.40.2",AUDIO="audio"
+180p-video-high.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=620000,AVERAGE-BANDWIDTH=500000,RESOLUTION=512x288,CLOSED-CAPTIONS=NONE,CODECS="avc1.4d401f,mp4a.40.2",AUDIO="audio"
+288p-video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=874000,AVERAGE-BANDWIDTH=692000,RESOLUTION=640x360,CLOSED-CAPTIONS=NONE,CODECS="avc1.4d401f,mp4a.40.2",AUDIO="audio"
+360p-video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1378000,AVERAGE-BANDWIDTH=1030000,RESOLUTION=768x432,CLOSED-CAPTIONS=NONE,CODECS="avc1.4d401f,mp4a.40.2",AUDIO="audio"
+432p-video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2230000,AVERAGE-BANDWIDTH=1682000,RESOLUTION=1280x720,CLOSED-CAPTIONS=NONE,CODECS="avc1.4d401f,mp4a.40.2",AUDIO="audio"
+720p-video.m3u8
+"""
+
+fileprivate let altVideoAltSubtitlesMuxedSample = """
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="video",NAME="alt video",URI="alt_video.m3u8"
+#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="video",NAME="video"
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="english subtitles",LANGUAGE="en",ASSOC-LANGUAGE="en-US",URI="subtitles.subs"
+
+#EXT-X-STREAM-INF:BANDWIDTH=500000,RESOLUTION=512x288,CODECS="avc1.4d401f,mp4a.40.2",VIDEO="video",SUBTITLES="subs"
+288p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1300000,RESOLUTION=768x432,CODECS="avc1.4d401f,mp4a.40.2",VIDEO="video",SUBTITLES="subs"
+432p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2200000,RESOLUTION=1280x720,CODECS="avc1.4d401f,mp4a.40.2",VIDEO="video",SUBTITLES="subs"
+720p-muxed.m3u8
+"""
+
+fileprivate let muxedSample = """
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=500000,RESOLUTION=512x288,CODECS="avc1.4d401f,mp4a.40.2"
+288p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1300000,RESOLUTION=768x432,CODECS="avc1.4d401f,mp4a.40.2"
+432p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2200000,RESOLUTION=1280x720,CODECS="avc1.4d401f,mp4a.40.2"
+720p-muxed.m3u8
+"""
+
+fileprivate let brokenSample = """
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=500000,RESOLUTION=512x288,CODECS="avc1.4d401f,mp4a.40.2"
+# Missing a location tag here!
+#EXT-X-STREAM-INF:BANDWIDTH=1300000,RESOLUTION=768x432,CODECS="avc1.4d401f,mp4a.40.2"
+432p-muxed.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2200000,RESOLUTION=1280x720,CODECS="avc1.4d401f,mp4a.40.2"
+720p-muxed.m3u8
+"""


### PR DESCRIPTION
### Description

This PR implements feature #40.

It can be useful to be able to analyze the stream content of a master playlist.

This PR adds a function on `MasterPlaylist` to get a summary of all the independent streams in that playlist. This includes an analysis of whether each stream is demuxed audio, demuxed video, or mixed audio/video.

### Change Notes

* Added new function on `MasterPlaylist`: `calculateStreamSummary`. This returns a `ResultType` with a `PlaylistStreamSummary` on success and a `StreamSummaryError` on failure.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.