### PR TITLE
FailableStringLiteralConvertible init made clearer and more distinct.

### DIFF
--- a/mambaSharedFramework/Pantos-Generic Playlist Parsing/Pantos-Generic Tag Validators/GenericDictionaryTagValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic Playlist Parsing/Pantos-Generic Tag Validators/GenericDictionaryTagValidator.swift
@@ -44,7 +44,7 @@ public class GenericDictionaryTagValidator: PlaylistTagValidator {
             
             if let value: String = tag.value(forValueIdentifier: identifier.valueId) {
                 
-                guard let _ = identifier.expectedType.init(string: value) else {
+                guard let _ = identifier.expectedType.init(failableInitWithString: value) else {
                     issueList.append(PlaylistValidationIssue(description: "\(tag.tagDescriptor.toString()) \(identifier.valueId)=\(value) is not an instance of the expected data type \(identifier.expectedType).", severity: IssueSeverity.error))
                     continue
                 }

--- a/mambaSharedFramework/Pantos-Generic Playlist Parsing/Pantos-Generic Tag Validators/GenericSingleTagValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic Playlist Parsing/Pantos-Generic Tag Validators/GenericSingleTagValidator.swift
@@ -47,7 +47,7 @@ public class GenericSingleTagValidator<S: FailableStringLiteralConvertible>: Pla
             issueList.append(PlaylistValidationIssue(description: "\(tag.tagDescriptor.toString()) value is empty.", severity: IssueSeverity.error))
             return issueList
         }
-        guard let _ = S(string: value) else {
+        guard let _ = S(failableInitWithString: value) else {
             issueList.append(PlaylistValidationIssue(description: "\(tag.tagDescriptor.toString()) (\(value)) is not an instance of the expected data type.", severity: IssueSeverity.error))
             return issueList
         }

--- a/mambaSharedFramework/Pantos-Generic Playlist Parsing/Pantos-Generic Tag Validators/PlaylistRenditionGroupAudioVideoValidator.swift
+++ b/mambaSharedFramework/Pantos-Generic Playlist Parsing/Pantos-Generic Tag Validators/PlaylistRenditionGroupAudioVideoValidator.swift
@@ -32,7 +32,7 @@ extension PlaylistRenditionGroupAudioVideoValidator {
             for tag in tags.filter({ $0.tagDescriptor == PantosTag.EXT_X_STREAM_INF }) {
                 
                 if let value: String = tag.value(forValueIdentifier: PantosValue.codecs),
-                    let codecs = CodecValueTypeArray(string: value) {
+                    let codecs = CodecValueTypeArray(failableInitWithString: value) {
                     
                     if let _ = codecArray {
                         guard let previousCodecs = codecArray else { return [PlaylistValidationIssue]() }

--- a/mambaSharedFramework/Playlist Models/PlaylistTag.swift
+++ b/mambaSharedFramework/Playlist Models/PlaylistTag.swift
@@ -258,7 +258,7 @@ public struct PlaylistTag: CustomDebugStringConvertible {
             return nil
         }
         
-        return T(string: stringValue)
+        return T(failableInitWithString: stringValue)
     }
     
     // MARK: Value setters

--- a/mambaSharedFramework/Utils/FailableStringLiteralConvertible.swift
+++ b/mambaSharedFramework/Utils/FailableStringLiteralConvertible.swift
@@ -21,23 +21,23 @@ import Foundation
 
 /// A protocol for objects that can be constructed from a string, but might fail.
 public protocol FailableStringLiteralConvertible {
-    init?(string: String)
+    init?(failableInitWithString: String)
 }
 
 extension Int: FailableStringLiteralConvertible {
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(string, radix: 10)
     }
 }
 
 extension Float: FailableStringLiteralConvertible {
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(string)
     }
 }
 
 extension Double: FailableStringLiteralConvertible {
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(string)
     }
 }
@@ -47,7 +47,7 @@ extension Bool: FailableStringLiteralConvertible {
         case No = "NO"
         case Yes = "YES"
     }
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         guard let value = YesNo.init(rawValue: string) else {
             return nil
         }
@@ -56,13 +56,13 @@ extension Bool: FailableStringLiteralConvertible {
 }
 
 extension String: FailableStringLiteralConvertible {
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(string)
     }
 }
 
 extension Date: FailableStringLiteralConvertible {
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         guard let date = string.parseISO8601Date() else {
             return nil
         }
@@ -72,7 +72,7 @@ extension Date: FailableStringLiteralConvertible {
 }
 
 extension CMTime: FailableStringLiteralConvertible {
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self = mamba_CMTimeMakeFromString(string, UInt8(CMTime.defaultMambaPrecision), nil)
     }
 }

--- a/mambaSharedFramework/Utils/PlaylistTag+Util.swift
+++ b/mambaSharedFramework/Utils/PlaylistTag+Util.swift
@@ -34,7 +34,7 @@ public extension PlaylistTag {
     /// convenience function to return the codecs of this tag (if present)
     func codecs() -> CodecValueTypeArray? {
         if let value: String = self.value(forValueIdentifier: PantosValue.codecs) {
-            return CodecValueTypeArray(string: value)
+            return CodecValueTypeArray(failableInitWithString: value)
         }
         
         return nil

--- a/mambaSharedFramework/ValueTypes.swift
+++ b/mambaSharedFramework/ValueTypes.swift
@@ -29,7 +29,7 @@ public typealias MediaGroupIndexRange = CountableClosedRange<Int>
 public struct ResolutionValueType: Equatable, Comparable, FailableStringLiteralConvertible {
     public let w: Int
     public let h: Int
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(resolution: string)
     }
     public init?(resolution: String) {
@@ -84,7 +84,7 @@ public struct MediaType: Equatable, FailableStringLiteralConvertible {
         case Subtitles = "SUBTITLES"
         case ClosedCaptions = "CLOSED-CAPTIONS"
     }
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(mediaType: string)
     }
     public init?(mediaType: String) {
@@ -128,7 +128,7 @@ public struct EncryptionMethodType: Equatable, FailableStringLiteralConvertible 
         case AES128 = "AES-128"
         case SampleAES = "SAMPLE-AES"
     }
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(encryption: string)
     }
     public init?(encryption: String) {
@@ -155,7 +155,7 @@ public struct PlaylistValueType: Equatable, FailableStringLiteralConvertible {
         case Event = "EVENT"
         case VOD = "VOD"
     }
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(playlistType: string)
     }
     public init?(playlistType: String) {
@@ -183,7 +183,7 @@ public enum InstreamId: String, FailableStringLiteralConvertible {
     case CC3 = "CC3"
     case CC4 = "CC4"
     
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         self.init(rawValue:string)
     }
     
@@ -195,7 +195,7 @@ public enum InstreamId: String, FailableStringLiteralConvertible {
 /// can be either a quoted-string or an enumerated-string with the value NONE for a valid value
 public struct ClosedCaptionsValueType: FailableStringLiteralConvertible {
     let value: String
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         if !(string.hasPrefix("\"") && string.hasSuffix("\"")){
             if string != "NONE" {
                 return nil
@@ -232,7 +232,7 @@ public struct CodecValueTypeArray: Equatable, FailableStringLiteralConvertible {
     
     public let codecs: [CodecValueType]
     
-    public init?(string: String) {
+    public init?(failableInitWithString string: String) {
         let stringArray = StringArrayParser.parseToArray(fromParsableString: string, ignoreQuotes: true)
         if (stringArray.count == 0) {
             return nil

--- a/mambaTests/Util Tests/Value Types/CodecArrayTests.swift
+++ b/mambaTests/Util Tests/Value Types/CodecArrayTests.swift
@@ -26,17 +26,17 @@ class CodecValueTypeArrayTests: XCTestCase {
     func testCodecValueTypeArray() {
         let codecs1 = runTestsOn(codecString: "avc1.4d401f,mp4a.40.5")
         
-        let codecs2 = CodecValueTypeArray(string: "avc1.4d401f,mp4a.40.5")
-        let codecs3 = CodecValueTypeArray(string: "avc1.640029,mp4a.40.5")
+        let codecs2 = CodecValueTypeArray(failableInitWithString: "avc1.4d401f,mp4a.40.5")
+        let codecs3 = CodecValueTypeArray(failableInitWithString: "avc1.640029,mp4a.40.5")
         
         XCTAssertTrue(codecs1 == codecs2, "Equality operation should function")
         XCTAssertTrue(codecs1 != codecs3, "Equality operation should function")
         
-        let codecs4 = CodecValueTypeArray(string: "")
+        let codecs4 = CodecValueTypeArray(failableInitWithString: "")
         
         XCTAssertNil(codecs4, "Should have been created")
         
-        let codecs5 = CodecValueTypeArray(string: "mp4a.40.5")
+        let codecs5 = CodecValueTypeArray(failableInitWithString: "mp4a.40.5")
         XCTAssertTrue(codecs5?.containsAudio() ?? false, "Should contain audio")
         XCTAssertFalse(codecs5?.containsVideo() ?? false, "Should contain video")
         XCTAssertTrue(codecs5?.containsAudioOnly() ?? false, "Should contain only audio")
@@ -85,7 +85,7 @@ class CodecValueTypeArrayTests: XCTestCase {
                    expectingVideo: Bool,
                    expectingAudio: Bool) {
         
-        let codecs = CodecValueTypeArray(string: codecString)
+        let codecs = CodecValueTypeArray(failableInitWithString: codecString)
         
         XCTAssert(codecs?.containsAudioOnly() == expectingAudioOnly, "Expecting a audio only value of \(expectingAudioOnly) for codecs: \"\(codecString)\"")
         XCTAssert(codecs?.containsVideo() == expectingVideo, "Expecting a video value of \(expectingVideo) for codecs: \"\(codecString)\"")
@@ -93,7 +93,7 @@ class CodecValueTypeArrayTests: XCTestCase {
     }
     
     func runTestsOn(codecString: String) -> CodecValueTypeArray {
-        let codecs1 = CodecValueTypeArray(string: codecString)
+        let codecs1 = CodecValueTypeArray(failableInitWithString: codecString)
         
         XCTAssertNotNil(codecs1, "Should have been created")
         XCTAssert(codecs1?.codecs.count == 2, "Should have two codecs")

--- a/mambaTests/VariantPlaylistTagMatchSegmentInfoTests.swift
+++ b/mambaTests/VariantPlaylistTagMatchSegmentInfoTests.swift
@@ -65,7 +65,7 @@ segment5.ts
             XCTFail("Not expecting this value")
         case .timeMatch(let timeRange):
             XCTAssertEqual(timeRange.start, CMTime.zero)
-            XCTAssertEqual(timeRange.duration, CMTime(string: "3.0000")!)
+            XCTAssertEqual(timeRange.duration, CMTime(failableInitWithString: "3.0000")!)
         }
         
         // testing if the "match in header means no match" feature works
@@ -89,8 +89,8 @@ segment5.ts
         case .noTimeMatchForNonVODPlaylist:
             XCTFail("Not expecting this value")
         case .timeMatch(let timeRange):
-            XCTAssertEqual(timeRange.start, CMTime(string: "6.0000")!)
-            XCTAssertEqual(timeRange.duration, CMTime(string: "3.0000")!)
+            XCTAssertEqual(timeRange.start, CMTime(failableInitWithString: "6.0000")!)
+            XCTAssertEqual(timeRange.duration, CMTime(failableInitWithString: "3.0000")!)
         }
         
         XCTAssertEqual(testSegmentTags[1].containsDiscontinuity, true)
@@ -103,8 +103,8 @@ segment5.ts
         case .noTimeMatchForNonVODPlaylist:
             XCTFail("Not expecting this value")
         case .timeMatch(let timeRange):
-            XCTAssertEqual(timeRange.start, CMTime(string: "12.0000")!)
-            XCTAssertEqual(timeRange.duration, CMTime(string: "3.0000")!)
+            XCTAssertEqual(timeRange.start, CMTime(failableInitWithString: "12.0000")!)
+            XCTAssertEqual(timeRange.duration, CMTime(failableInitWithString: "3.0000")!)
         }
         
         // quick test of testing more "normal" segment based tags with "match in header means no match"


### PR DESCRIPTION
### Description

This PR implements feature #14.

This PR changes the initializer name for `FailableStringLiteralConvertible` to be much more specific and not easily confused with other potential initializers.

### Change Notes

* `FailableStringLiteralConvertible` init changed to `init?(failableInitWithString: String)`

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code. **No new docs are required**
- [ ] I have written unit tests for this new feature. **No new unit tests are required**

