### PR TITLE
Don't export Collection subscript(safe:) extension

### DIFF
--- a/mambaSharedFramework/Utils/Collections/CollectionType+Safe.swift
+++ b/mambaSharedFramework/Utils/Collections/CollectionType+Safe.swift
@@ -32,7 +32,7 @@ extension Collection {
 ///      <do stuff>
 ///  }
 /// http://stackoverflow.com/questions/25329186/safe-bounds-checked-array-lookup-in-swift-through-optional-bindings
-public extension Collection {
+extension Collection {
     /// Returns the element at the specified index iff it is within bounds, otherwise nil.
     subscript (safe index: Index) -> Iterator.Element? {
         return indicies(containsIndex: index) ? self[index] : nil


### PR DESCRIPTION
### Description

This PR fixes a minor bug where the Collection subscript(safe:) extension was exposed outside of the library causing the error `ambiguous use of 'subscript(safe:)'` in host apps that have defined the same extension.

### Change Notes

* Removed `public` from the Collection subscript(safe:) extension to keep it private to the mamba library

### Pre-submission Checklist

- [X] I ran the unit tests locally before checking in.
- [X] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

