### PR TITLE
Removing broken utility methods on Array<PlaylistTag>

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -2300,6 +2300,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2326,6 +2327,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2389,6 +2391,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = mamba;
 				SDKROOT = appletvos;
@@ -2418,6 +2421,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = mamba;
 				SDKROOT = appletvos;
@@ -2495,6 +2499,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
 				PRODUCT_NAME = mamba;
@@ -2527,6 +2532,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
 				PRODUCT_NAME = mamba;

--- a/mamba/Info.plist
+++ b/mamba/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/mambaMacOS/Info.plist
+++ b/mambaMacOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/mambaSharedFramework/Utils/Collections/PlaylistTagArray+RenditionGroups.swift
+++ b/mambaSharedFramework/Utils/Collections/PlaylistTagArray+RenditionGroups.swift
@@ -51,21 +51,6 @@ public extension Collection where Iterator.Element == PlaylistTag {
         return .unknown
     }
     
-    /// returns true if we can detect a SAP stream (only works for master playlists)
-    func hasSap() -> Bool {
-        
-        let languages = Set(self.extractValues(tagDescriptor: PantosTag.EXT_X_MEDIA, valueIdentifier: PantosValue.language))
-        return languages.count > 1
-    }
-    
-    /// returns the #EXT-X-MEDIA tags for SAP audio streams if present (only works for master playlists)
-    func sapStreams() -> [PlaylistTag]? {
-        
-        return self.filter({ $0.tagDescriptor == PantosTag.EXT_X_MEDIA }).filter({
-            return $0.value(forValueIdentifier: PantosValue.language) != nil
-        })
-    }
-    
     /// Convenience function to return all the values for a particular PlaylistTagValueIdentifier in a particular PlaylistTagDescriptor
     func extractValues(tagDescriptor: PlaylistTagDescriptor, valueIdentifier: PlaylistTagValueIdentifier) -> Set<String> {
         
@@ -82,29 +67,11 @@ public extension Collection where Iterator.Element == PlaylistTag {
         return values
     }
     
-    /// returns true if we are a master playlist and have a audio only stream
-    func hasAudioOnlyStream() -> Bool {
-        
-        guard let _ = firstAudioOnlyStreamInfTag() else { return false }
-        return true
-    }
-    
-    /// returns the first audio only #EXT-X-STREAMINF tag found in this PlaylistTag collection
-    func firstAudioOnlyStreamInfTag() -> PlaylistTag? {
-        return first(where: { $0.tagDescriptor == PantosTag.EXT_X_STREAM_INF && $0.isAudioOnlyStream() == .TRUE })
-    }
-    
     /// Convenience function to filter PlaylistTag collections by a particular PlaylistTagDescriptor
     func filtered(by tagDescriptor: PlaylistTagDescriptor) -> [PlaylistTag] {
         return self.filter({ $0.tagDescriptor == tagDescriptor })
     }
 
-    /// Convenience function to return just the video streams in a PlaylistTag collection
-    func filteredByVideoCodec() -> [PlaylistTag] {
-        
-        return self.filter { return $0.isVideoStream() == .TRUE }
-    }
-    
     /// returns a new PlaylistTag Array that's sorted by resolution and bandwidth (in that order)
     func sortedByResolutionBandwidth(tolerance: Double = 1.0) -> [PlaylistTag] {
         

--- a/mambaTests/TagCollectionTests.swift
+++ b/mambaTests/TagCollectionTests.swift
@@ -22,35 +22,6 @@ import XCTest
 
 class TagCollectionTests: XCTestCase {
     
-    func testSAP() {
-        let sapMaster = parseMasterPlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-        let nonsapMaster = parseMasterPlaylist(inFixtureName: "hls_sampleMasterFile.txt")
-        
-        XCTAssertTrue(sapMaster.tags.hasSap())
-        XCTAssertFalse(nonsapMaster.tags.hasSap())
-        
-        XCTAssertEqual(sapMaster.tags.sapStreams()?.count, 4)
-        XCTAssertEqual(nonsapMaster.tags.sapStreams()?.count, 0)
-    }
-    
-    func testAudioOnlyStream() {
-        let audioOnlyMaster = parseMasterPlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-        let nonAudioOnlyMaster = parseMasterPlaylist(inFixtureName: "hls_sampleMasterFile.txt")
-
-        XCTAssertTrue(audioOnlyMaster.tags.hasAudioOnlyStream())
-        XCTAssertFalse(nonAudioOnlyMaster.tags.hasAudioOnlyStream())
-        
-        XCTAssertNotNil(audioOnlyMaster.tags.firstAudioOnlyStreamInfTag())
-        XCTAssertNil(nonAudioOnlyMaster.tags.firstAudioOnlyStreamInfTag())
-    }
-    
-    func testFilteredBy() {
-        let master = parseMasterPlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-
-        XCTAssertEqual(master.tags.filtered(by: PantosTag.EXT_X_MEDIA).count, 4)
-        XCTAssertEqual(master.tags.filteredByVideoCodec().count, 7)
-    }
-    
     func testSortedBy() {
         let master = parseMasterPlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
 


### PR DESCRIPTION
### Description

This PR removes some methods that were not working correctly.

We're sorry to break existing functionality, but if you were using these methods, they were likely incorrect in some cases and should be replaced.

### Change Notes

* Removed `hasSap` `sapStreams` `hasAudioOnlyStream` `firstAudioOnlyStreamInfTag` and `filteredByVideoCodec` from the `Array<PlaylistTag>` extension.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

