### PR TITLE
Removing broken utility methods on Array<HLSTag> (1.x branch)

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -2235,6 +2235,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2259,6 +2260,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2319,6 +2321,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = mamba;
 				SDKROOT = appletvos;
@@ -2348,6 +2351,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = mamba;
 				SDKROOT = appletvos;
@@ -2425,6 +2429,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
 				PRODUCT_NAME = mamba;
@@ -2457,6 +2462,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
 				PRODUCT_NAME = mamba;

--- a/mamba/Info.plist
+++ b/mamba/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/mambaMacOS/Info.plist
+++ b/mambaMacOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/mambaSharedFramework/HLS Utils/Collections/HLSTagArray+RenditionGroups.swift
+++ b/mambaSharedFramework/HLS Utils/Collections/HLSTagArray+RenditionGroups.swift
@@ -35,21 +35,6 @@ public extension Collection where Iterator.Element == HLSTag {
         return .unknown
     }
     
-    /// returns true if we can detect a SAP stream (only works for master playlists)
-    func hasSap() -> Bool {
-        
-        let languages = Set(self.extractValues(tagDescriptor: PantosTag.EXT_X_MEDIA, valueIdentifier: PantosValue.language))
-        return languages.count > 1
-    }
-    
-    /// returns the #EXT-X-MEDIA tags for SAP audio streams if present (only works for master playlists)
-    func sapStreams() -> [HLSTag]? {
-        
-        return self.filter({ $0.tagDescriptor == PantosTag.EXT_X_MEDIA }).filter({
-            return $0.value(forValueIdentifier: PantosValue.language) != nil
-        })
-    }
-    
     /// Convenience function to return all the values for a particular HLSTagValueIdentifier in a particular HLSTagDescriptor
     func extractValues(tagDescriptor: HLSTagDescriptor, valueIdentifier: HLSTagValueIdentifier) -> Set<String> {
         
@@ -66,28 +51,10 @@ public extension Collection where Iterator.Element == HLSTag {
         return values
     }
     
-    /// returns true if we are a master playlist and have a audio only stream
-    func hasAudioOnlyStream() -> Bool {
-        
-        guard let _ = firstAudioOnlyStreamInfTag() else { return false }
-        return true
-    }
-    
-    /// returns the first audio only #EXT-X-STREAMINF tag found in this HLSTag collection
-    func firstAudioOnlyStreamInfTag() -> HLSTag? {
-        return first(where: { $0.tagDescriptor == PantosTag.EXT_X_STREAM_INF && $0.isAudioOnlyStream() == .TRUE })
-    }
-    
     /// Convenience function to filter HLSTag collections by a particular HLSTagDescriptor
     func filtered(by tagDescriptor: HLSTagDescriptor) -> [HLSTag] {
         
         return self.filter({ $0.tagDescriptor == tagDescriptor })
-    }
-
-    /// Convenience function to return just the video streams in a HLSTag collection
-    func filteredByVideoCodec() -> [HLSTag] {
-        
-        return self.filter { return $0.isVideoStream() == .TRUE }
     }
     
     /// returns a new HLSTag Array that's sorted by resolution and bandwidth (in that order)

--- a/mambaTests/HLSTagCollectionTests.swift
+++ b/mambaTests/HLSTagCollectionTests.swift
@@ -22,35 +22,6 @@ import XCTest
 
 class HLSTagCollectionTests: XCTestCase {
     
-    func testSAP() {
-        let sapMaster = parsePlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-        let nonsapMaster = parsePlaylist(inFixtureName: "hls_sampleMasterFile.txt")
-        
-        XCTAssertTrue(sapMaster.tags.hasSap())
-        XCTAssertFalse(nonsapMaster.tags.hasSap())
-        
-        XCTAssertEqual(sapMaster.tags.sapStreams()?.count, 4)
-        XCTAssertEqual(nonsapMaster.tags.sapStreams()?.count, 0)
-    }
-    
-    func testAudioOnlyStream() {
-        let audioOnlyMaster = parsePlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-        let nonAudioOnlyMaster = parsePlaylist(inFixtureName: "hls_sampleMasterFile.txt")
-
-        XCTAssertTrue(audioOnlyMaster.tags.hasAudioOnlyStream())
-        XCTAssertFalse(nonAudioOnlyMaster.tags.hasAudioOnlyStream())
-        
-        XCTAssertNotNil(audioOnlyMaster.tags.firstAudioOnlyStreamInfTag())
-        XCTAssertNil(nonAudioOnlyMaster.tags.firstAudioOnlyStreamInfTag())
-    }
-    
-    func testFilteredBy() {
-        let master = parsePlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
-
-        XCTAssertEqual(master.tags.filtered(by: PantosTag.EXT_X_MEDIA).count, 4)
-        XCTAssertEqual(master.tags.filteredByVideoCodec().count, 7)
-    }
-    
     func testSortedBy() {
         let master = parsePlaylist(inFixtureName: "super8demuxed1_4242.m3u8")
 


### PR DESCRIPTION
### Description

This PR removes some methods that were not working correctly.

We're sorry to break existing functionality, but if you were using these methods, they were likely incorrect in some cases and should be replaced.

### Change Notes

* Removed `hasSap` `sapStreams` `hasAudioOnlyStream` `firstAudioOnlyStreamInfTag` and `filteredByVideoCodec` from the Array<PlaylistTag> extension.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

