### PR TITLE
Workaround for static libs for swift/objc projects

### DIFF
--- a/mambaSharedFramework/Rapid Parser/RapidParserError.m
+++ b/mambaSharedFramework/Rapid Parser/RapidParserError.m
@@ -18,7 +18,11 @@
 //
 
 #include "RapidParserError.h"
-#import <mamba/mamba-Swift.h>
+#if __has_include("mamba-Swift.h")
+    #import "mamba-Swift.h"
+#else
+    #import <mamba/mamba-Swift.h>
+#endif
 
 const uint32_t RapidParserErrorMissingTagData = PlaylistParserInternalErrorCodeMissingTagData;
 


### PR DESCRIPTION
### Description

This PR implements a [workaround](https://github.com/CocoaPods/CocoaPods/issues/7594) to allow the generation of static library using cocoapods.

Use case 1:
```
target 'App' do
  use_modular_headers!
  pod 'mamba', '2.2.0'
end
```

Use case 2 (without global a `use_frameworks!`):
```
target 'App' do
  pod 'mamba', '2.2.0'
end
```
### Change Notes

* Added new import macro to `RapidParserError.m`.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

