### PR TITLE
Fixing XCode 11.5 warnings

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -1599,7 +1599,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1150;
 				ORGANIZATIONNAME = "Comcast Corporation.\n//  Licensed under the Apache License, Version 2.0 (the \"License\");\n//  you may not use this file except in compliance with the License.\n//  You may obtain a copy of the License at\n//\n//  http://www.apache.org/licenses/LICENSE-2.0\n//\n//  Unless required by applicable law or agreed to in writing, software\n//  distributed under the License is distributed on an \"AS IS\" BASIS,\n//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n//  See the License for the specific language governing permissions and\n//  limitations under the License.";
 				TargetAttributes = {
 					EC15214E1DD28536006FB265 = {

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
@@ -288,13 +288,13 @@ public extension PlaylistStream {
     // returns the `StreamType` for this stream if applicable.
     var streamType: StreamType? {
         switch self {
-        case .audioMediaStream(_):
+        case .audioMediaStream(_, _, _, _, _, _):
             return .demuxedAudio
-        case .videoMediaStream(_):
+        case .videoMediaStream(_, _, _, _, _, _):
             return .demuxedVideo
-        case .subtitlesMediaStream(_):
+        case .subtitlesMediaStream(_, _, _):
             return nil
-        case .iFrameStream(_):
+        case .iFrameStream(_, _):
             return nil
         case .stream(_, _, _, _, _, _, let streamType, _, _):
             return streamType

--- a/mambaTests/MasterPlaylistStreamSummaryTests.swift
+++ b/mambaTests/MasterPlaylistStreamSummaryTests.swift
@@ -92,9 +92,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
                     XCTFail("Unexpected mediaIndex: \(mediaIndex)")
                 }
                 break
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1
@@ -248,9 +248,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
                 default:
                     XCTFail("Unexpected mediaIndex: \(mediaIndex)")
                 }
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1
@@ -363,7 +363,7 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
         
         for stream in summary.streams {
             switch stream {
-            case .iFrameStream(_):
+            case .iFrameStream(_, _):
                 XCTFail("Unexpected iframe stream")
             case .audioMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
                 audioCount += 1
@@ -379,9 +379,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
                 default:
                     XCTFail("Unexpected mediaIndex: \(mediaIndex)")
                 }
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1
@@ -486,9 +486,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
         
         for stream in summary.streams {
             switch stream {
-            case .iFrameStream(_):
+            case .iFrameStream(_, _):
                 XCTFail("Unexpected iframe stream")
-            case .audioMediaStream(_):
+            case .audioMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected audio stream")
             case .videoMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
                 videoCount += 1
@@ -580,13 +580,13 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
         
         for stream in summary.streams {
             switch stream {
-            case .iFrameStream(_):
+            case .iFrameStream(_, _):
                 XCTFail("Unexpected iframe stream")
-            case .audioMediaStream(_):
+            case .audioMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected audio stream")
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1


### PR DESCRIPTION
### Description

This PR fixes warnings found in Xcode 11.5

### Change Notes

* Added correct number of `_` placeholders for associated type enum switch statements

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

