### PR TITLE
Release/2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,6 @@ If you do, for some reason, need to access `PlaylistTag` data beyond the lifetim
 
 --
 
-_Note: We have legacy branches for mamba 1.x at [our master 1.x branch](https://github.com/Comcast/mamba/tree/master_1.x) and [our develop 1.x branch](https://github.com/Comcast/mamba/tree/develop_1.x). However, we are not maintaining that branch actively. Users are welcome to submit pull requests against the 1.x branches or potentially fork if they do not want to move to 2.0_
+_Note: We have legacy branches for mamba 1.x at [our main 1.x branch](https://github.com/Comcast/mamba/tree/main_1.x) and [our develop 1.x branch](https://github.com/Comcast/mamba/tree/develop_1.x). We are maintaining that branch, but may stop updating in the near future. Users are welcome to submit pull requests against the 1.x branches or potentially fork if they do not want to move to 2.0_
 
 --

--- a/mamba.podspec
+++ b/mamba.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name              = "mamba"
-s.version           = "2.2.0"
+s.version           = "2.2.1"
 s.license           = { :type => 'Apache License, Version 2.0',
                         :text => <<-LICENSE
                             Copyright 2017 Comcast Cable Communications Management, LLC

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -1599,7 +1599,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1150;
 				ORGANIZATIONNAME = "Comcast Corporation.\n//  Licensed under the Apache License, Version 2.0 (the \"License\");\n//  you may not use this file except in compliance with the License.\n//  You may obtain a copy of the License at\n//\n//  http://www.apache.org/licenses/LICENSE-2.0\n//\n//  Unless required by applicable law or agreed to in writing, software\n//  distributed under the License is distributed on an \"AS IS\" BASIS,\n//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n//  See the License for the specific language governing permissions and\n//  limitations under the License.";
 				TargetAttributes = {
 					EC15214E1DD28536006FB265 = {

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -2324,7 +2324,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2351,7 +2351,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2415,7 +2415,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = mamba;
 				SDKROOT = appletvos;
@@ -2445,7 +2445,7 @@
 				INFOPLIST_FILE = mamba/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_NAME = mamba;
 				SDKROOT = appletvos;
@@ -2523,7 +2523,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
 				PRODUCT_NAME = mamba;
@@ -2556,7 +2556,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
 				PRODUCT_NAME = mamba;

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Concrete Types/MasterPlaylistStreamSummary.swift
@@ -288,13 +288,13 @@ public extension PlaylistStream {
     // returns the `StreamType` for this stream if applicable.
     var streamType: StreamType? {
         switch self {
-        case .audioMediaStream(_):
+        case .audioMediaStream(_, _, _, _, _, _):
             return .demuxedAudio
-        case .videoMediaStream(_):
+        case .videoMediaStream(_, _, _, _, _, _):
             return .demuxedVideo
-        case .subtitlesMediaStream(_):
+        case .subtitlesMediaStream(_, _, _):
             return nil
-        case .iFrameStream(_):
+        case .iFrameStream(_, _):
             return nil
         case .stream(_, _, _, _, _, _, let streamType, _, _):
             return streamType

--- a/mambaSharedFramework/Rapid Parser/RapidParserError.m
+++ b/mambaSharedFramework/Rapid Parser/RapidParserError.m
@@ -18,7 +18,11 @@
 //
 
 #include "RapidParserError.h"
-#import <mamba/mamba-Swift.h>
+#if __has_include("mamba-Swift.h")
+    #import "mamba-Swift.h"
+#else
+    #import <mamba/mamba-Swift.h>
+#endif
 
 const uint32_t RapidParserErrorMissingTagData = PlaylistParserInternalErrorCodeMissingTagData;
 

--- a/mambaTests/MasterPlaylistStreamSummaryTests.swift
+++ b/mambaTests/MasterPlaylistStreamSummaryTests.swift
@@ -92,9 +92,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
                     XCTFail("Unexpected mediaIndex: \(mediaIndex)")
                 }
                 break
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1
@@ -248,9 +248,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
                 default:
                     XCTFail("Unexpected mediaIndex: \(mediaIndex)")
                 }
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1
@@ -363,7 +363,7 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
         
         for stream in summary.streams {
             switch stream {
-            case .iFrameStream(_):
+            case .iFrameStream(_, _):
                 XCTFail("Unexpected iframe stream")
             case .audioMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
                 audioCount += 1
@@ -379,9 +379,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
                 default:
                     XCTFail("Unexpected mediaIndex: \(mediaIndex)")
                 }
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1
@@ -486,9 +486,9 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
         
         for stream in summary.streams {
             switch stream {
-            case .iFrameStream(_):
+            case .iFrameStream(_, _):
                 XCTFail("Unexpected iframe stream")
-            case .audioMediaStream(_):
+            case .audioMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected audio stream")
             case .videoMediaStream(let mediaIndex, let uri, let groupId, let name, let language, let associatedLanguage):
                 videoCount += 1
@@ -580,13 +580,13 @@ class MasterPlaylistStreamSummaryTests: XCTestCase {
         
         for stream in summary.streams {
             switch stream {
-            case .iFrameStream(_):
+            case .iFrameStream(_, _):
                 XCTFail("Unexpected iframe stream")
-            case .audioMediaStream(_):
+            case .audioMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected audio stream")
-            case .videoMediaStream(_):
+            case .videoMediaStream(_, _, _, _, _, _):
                 XCTFail("Unexpected video stream")
-            case .subtitlesMediaStream(_):
+            case .subtitlesMediaStream(_, _, _):
                 XCTFail("Unexpected subtitles stream")
             case .stream(let streamInfIndex, let locationIndex, let uri, let audioGroupId, let videoGroupId, let captionsGroupId, let streamType, let bandwidth, let resolution):
                 streamInfCount += 1


### PR DESCRIPTION
### Description

This PR releases version 2.2.1 of mamba

### Change Notes

* Updates for Xcode 11.5
* Fixes static libs issue with CocoaPods
* README updates for branch naming changes

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

