### PR TITLE
Update to XCode 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.6
+osx_image: xcode11
 
 
 env:
@@ -13,8 +13,8 @@ env:
   - TVOS_SDK=appletvsimulator13.0
   - OSX_SDK=macosx10.15
   matrix:
-  - DESTINATION="OS=13.5,name=iPad Air (3rd generation)"              SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES"
-  - DESTINATION="OS=13.4,name=Apple TV 4K"           SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="YES"
+  - DESTINATION="OS=13.0,name=iPad Air (3rd generation)"              SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES"
+  - DESTINATION="OS=13.0,name=Apple TV 4K"           SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="YES"
   - DESTINATION="arch=x86_64"                        SDK="$OSX_SDK" SCHEME="$OSX_SCHEME" RUN_TESTS="YES"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11
+osx_image: xcode12
 
 
 env:
@@ -9,12 +9,12 @@ env:
   - IOS_SCHEME="mamba"
   - TVOS_SCHEME="mambaTVOS"
   - OSX_SCHEME="mambaMacOS"
-  - IOS_SDK=iphonesimulator13.0
-  - TVOS_SDK=appletvsimulator13.0
-  - OSX_SDK=macosx10.15
+  - IOS_SDK=iphonesimulator14.0
+  - TVOS_SDK=appletvos14.0
+  - OSX_SDK=macosx11.0
   matrix:
-  - DESTINATION="OS=13.0,name=iPad Air (3rd generation)"              SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES"
-  - DESTINATION="OS=13.0,name=Apple TV 4K"           SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="YES"
+  - DESTINATION="OS=14.0,name=iPad Air (3rd generation)"              SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES"
+  - DESTINATION="OS=14.0,name=Apple TV 4K"           SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="YES"
   - DESTINATION="arch=x86_64"                        SDK="$OSX_SDK" SCHEME="$OSX_SCHEME" RUN_TESTS="YES"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode12
+osx_image: xcode11.6
 
 
 env:
@@ -9,12 +9,12 @@ env:
   - IOS_SCHEME="mamba"
   - TVOS_SCHEME="mambaTVOS"
   - OSX_SCHEME="mambaMacOS"
-  - IOS_SDK=iphonesimulator14.0
-  - TVOS_SDK=appletvos14.0
-  - OSX_SDK=macosx11.0
+  - IOS_SDK=iphonesimulator13.0
+  - TVOS_SDK=appletvsimulator13.0
+  - OSX_SDK=macosx10.15
   matrix:
-  - DESTINATION="OS=14.0,name=iPad Air (3rd generation)"              SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES"
-  - DESTINATION="OS=14.0,name=Apple TV 4K"           SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="YES"
+  - DESTINATION="OS=13.5,name=iPad Air (3rd generation)"              SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES"
+  - DESTINATION="OS=13.4,name=Apple TV 4K"           SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="YES"
   - DESTINATION="arch=x86_64"                        SDK="$OSX_SDK" SCHEME="$OSX_SCHEME" RUN_TESTS="YES"
 
 script:

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -2522,7 +2522,7 @@
 				INFOPLIST_FILE = mambaMacOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
@@ -2555,7 +2555,7 @@
 				INFOPLIST_FILE = mambaMacOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -2522,7 +2522,7 @@
 				INFOPLIST_FILE = mambaMacOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;
@@ -2555,7 +2555,7 @@
 				INFOPLIST_FILE = mambaMacOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comcast.mamba;
 				PRODUCT_MODULE_NAME = mamba;

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -1599,7 +1599,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 1150;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = "Comcast Corporation.\n//  Licensed under the Apache License, Version 2.0 (the \"License\");\n//  you may not use this file except in compliance with the License.\n//  You may obtain a copy of the License at\n//\n//  http://www.apache.org/licenses/LICENSE-2.0\n//\n//  Unless required by applicable law or agreed to in writing, software\n//  distributed under the License is distributed on an \"AS IS\" BASIS,\n//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n//  See the License for the specific language governing permissions and\n//  limitations under the License.";
 				TargetAttributes = {
 					EC15214E1DD28536006FB265 = {
@@ -2638,6 +2638,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -2699,6 +2700,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = NO;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/mamba.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/mamba.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
 	<key>PreviewsEnabled</key>
 	<false/>
 </dict>

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mamba.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaMacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
+++ b/mamba.xcodeproj/xcshareddata/xcschemes/mambaTVOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mambaSharedFramework/Playlist Models/Playlist Structure/MasterPlaylistStructure.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Structure/MasterPlaylistStructure.swift
@@ -41,7 +41,7 @@ import Foundation
  variantTagGroups[2]   3.m3u8
  ```
  */
-public typealias MasterPlaylistStructure = PlaylistStructureCore<MasterPlaylistStructureData, MasterPlaylistStructureDelegate>
+public typealias MasterPlaylistStructure = PlaylistStructureCore<MasterPlaylistStructureDelegate>
 
 extension PlaylistStructureCore: MasterPlaylistTagGroupProvider where PSD == MasterPlaylistStructureDelegate {
     
@@ -68,7 +68,7 @@ public protocol MasterPlaylistTagGroupProvider {
     var variantTagGroups: [VariantTagGroup] { get }
 }
 
-public struct MasterPlaylistStructureData: EmptyInitializerImplementor {
+public struct MasterPlaylistStructureData: PlaylistStructure {
     public init() {
         self.variantTagGroups = [VariantTagGroup]()
     }
@@ -78,7 +78,7 @@ public struct MasterPlaylistStructureData: EmptyInitializerImplementor {
     var variantTagGroups: [VariantTagGroup]
 }
 
-public final class MasterPlaylistStructureDelegate: PlaylistStructureDelegate, EmptyInitializerImplementor {
+public final class MasterPlaylistStructureDelegate: PlaylistStructureDelegate {
 
     public typealias T = MasterPlaylistStructureData
     

--- a/mambaSharedFramework/Playlist Models/Playlist Structure/VariantPlaylistStructure.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Structure/VariantPlaylistStructure.swift
@@ -55,7 +55,7 @@ import Foundation
  mediaSpans[1] would cover just mediaSegmentGroup[2] (range 2...2). Each media span has its own #EXT-X-KEY tag.
  
  */
-public typealias VariantPlaylistStructure = PlaylistStructureCore<MediaPlaylistStructureData, VariantPlaylistStructureDelegate>
+public typealias VariantPlaylistStructure = PlaylistStructureCore<VariantPlaylistStructureDelegate>
 
 extension PlaylistStructureCore: PlaylistTagSource, PlaylistTypeDetermination, VariantPlaylistStructureInterface where PSD == VariantPlaylistStructureDelegate {
     
@@ -173,7 +173,7 @@ extension VariantPlaylistStructureInterface {
     }
 }
 
-public struct MediaPlaylistStructureData: EmptyInitializerImplementor, PlaylistTypeDetermination {
+public struct MediaPlaylistStructureData: PlaylistStructure, PlaylistTypeDetermination {
     public init() {
         self.header = nil
         self.mediaSegmentGroups = [MediaSegmentPlaylistTagGroup]()
@@ -207,7 +207,7 @@ public struct MediaPlaylistStructureData: EmptyInitializerImplementor, PlaylistT
     public var playlistType: PlaylistType
 }
 
-public final class VariantPlaylistStructureDelegate: PlaylistStructureDelegate, EmptyInitializerImplementor {
+public final class VariantPlaylistStructureDelegate: PlaylistStructureDelegate {
     
     public typealias T = MediaPlaylistStructureData
     

--- a/mambaSharedFramework/mamba.h
+++ b/mambaSharedFramework/mamba.h
@@ -17,7 +17,7 @@
 //  limitations under the License.
 //
 
-#import "Availability.h"
+#import <Availability.h>
 
 #ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
 #import <Cocoa/Cocoa.h>

--- a/mambaTests/Helpers/XCTestCase+mamba.swift
+++ b/mambaTests/Helpers/XCTestCase+mamba.swift
@@ -23,9 +23,9 @@ import XCTest
 
 extension XCTestCase {
     
-    public func parseMasterPlaylist(inData data: Data,
-                                    tagTypes: [PlaylistTagDescriptor.Type]? = nil,
-                                    url: URL = fakePlaylistURL()) -> MasterPlaylist {
+    fileprivate func _parseMasterPlaylist(inData data: Data,
+                                          tagTypes: [PlaylistTagDescriptor.Type]? = nil,
+                                          url: URL = fakePlaylistURL()) -> MasterPlaylist? {
         let result = _parsePlaylist(inData: data, tagTypes: tagTypes, url: url)
         switch result {
         case .parseError(let error):
@@ -38,9 +38,15 @@ extension XCTestCase {
             break
         }
         // we've already stopped the test at this point
-        return nil!
+        return nil
     }
     
+    public func parseMasterPlaylist(inData data: Data,
+                                    tagTypes: [PlaylistTagDescriptor.Type]? = nil,
+                                    url: URL = fakePlaylistURL()) -> MasterPlaylist {
+        return _parseMasterPlaylist(inData: data, tagTypes: tagTypes, url: url)!
+    }
+
     public func parseMasterPlaylist(inString playlistString: String,
                                     tagTypes: [PlaylistTagDescriptor.Type]? = nil,
                                     url: URL? = fakePlaylistURL()) -> MasterPlaylist {
@@ -59,9 +65,9 @@ extension XCTestCase {
         return parseMasterPlaylist(inData: data! as Data, tagTypes: tagTypes, url: url!)
     }
     
-    public func parseVariantPlaylist(inData data: Data,
-                                     tagTypes: [PlaylistTagDescriptor.Type]? = nil,
-                                     url: URL = fakePlaylistURL()) -> VariantPlaylist {
+    fileprivate func _parseVariantPlaylist(inData data: Data,
+                                           tagTypes: [PlaylistTagDescriptor.Type]? = nil,
+                                           url: URL = fakePlaylistURL()) -> VariantPlaylist? {
         let result = _parsePlaylist(inData: data, tagTypes: tagTypes, url: url)
         switch result {
         case .parseError(let error):
@@ -74,7 +80,13 @@ extension XCTestCase {
             break
         }
         // we've already stopped the test at this point
-        return nil!
+        return nil
+    }
+    
+    public func parseVariantPlaylist(inData data: Data,
+                                     tagTypes: [PlaylistTagDescriptor.Type]? = nil,
+                                     url: URL = fakePlaylistURL()) -> VariantPlaylist {
+        return _parseVariantPlaylist(inData: data, tagTypes: tagTypes, url: url)!
     }
     
     public func parseVariantPlaylist(inString playlistString: String,


### PR DESCRIPTION
### Description

This PR updates the project using Xcode 12.

### Change Notes

* To disable the "using old build system that will go away soon warning" I have switched to the new build system. This was causing this bug: https://github.com/Comcast/mamba/issues/66 in Xcode 10.3. I cannot make this happen now (although it was a race condition that was sporadic) so I'm hoping that it's fixed.
* Redid a unit test to be less crazy (i.e. `nil!`)
* Revamped some generics to to silence a warning, which also made the generics clearer.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

