### PR TITLE
Updated BuildSystemType

### DIFF
--- a/mamba.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/mamba.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Latest</string>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/mamba.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/mamba.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Latest</string>
 	<key>PreviewsEnabled</key>
 	<false/>
 </dict>


### PR DESCRIPTION
### Description

This PR fixes Carthage support for Xcode 13. This change prevents Carthage from using the legacy build system.

### Change Notes

* Updated BuildSystemType to Latest.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

