### PR TITLE
(codec) dvh: added to video list

### DIFF
--- a/mambaSharedFramework/HLSValueTypes.swift
+++ b/mambaSharedFramework/HLSValueTypes.swift
@@ -195,7 +195,7 @@ public struct HLSClosedCaptions: FailableStringLiteralConvertible {
 public struct HLSCodec: Equatable {
     
     static let audioPrefixes: [String] = ["mp4a", "mp3", "ec-3", "ac-3"]
-    static let videoPrefixes: [String] = ["avc", "mp4v", "svc", "mvc", "sevc", "s263", "hvc", "vp9"]
+    static let videoPrefixes: [String] = ["avc", "mp4v", "svc", "mvc", "sevc", "s263", "hvc", "vp9", "dvh"]
     public let codecDescriptor: String
     
     init(codecDescriptor: String) {


### PR DESCRIPTION
We’re getting an error from Helio saying those variants don’t match audio or video. I think we need to add dvh to this list:



> codec from the test stream CODECS="dvh1.08.03,mp4a.40.5"