### PR TITLE
Fixed a compilation error on Xcode 16 Beta with tvOS 18.

### DIFF
--- a/mambaSharedFramework/Rapid Parser/RapidParserError.h
+++ b/mambaSharedFramework/Rapid Parser/RapidParserError.h
@@ -21,6 +21,7 @@
 #define RapidParserError_h
 
 #include <stdio.h>
+#include <stdint.h>
 
 extern const uint32_t RapidParserErrorMissingTagData;
 

--- a/mambaSharedFramework/Rapid Parser/RapidParserNewTagCallbacks.h
+++ b/mambaSharedFramework/Rapid Parser/RapidParserNewTagCallbacks.h
@@ -21,6 +21,7 @@
 #define RapidParserCallback_h
 
 #include <stdbool.h>
+#include <stdint.h>
 
 void NewTagCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName, const uint64_t startTagData, const uint64_t endTagData);
 void NewTagNoDataCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName);

--- a/mambaSharedFramework/Rapid Parser/RapidParserState.h
+++ b/mambaSharedFramework/Rapid Parser/RapidParserState.h
@@ -21,6 +21,7 @@
 #define RapidParserState_h
 
 #include <stdio.h>
+#include <stdint.h>
 
 enum ParseState {
     // normal scanning state

--- a/mambaSharedFramework/Rapid Parser/RapidParserStateHandlers.h
+++ b/mambaSharedFramework/Rapid Parser/RapidParserStateHandlers.h
@@ -21,6 +21,7 @@
 #define RapidParserStateHandlers_h
 
 #include <stdio.h>
+#include <stdint.h>
 #include "RapidParserLineState.h"
 
 // Type definition of the standard parser handler


### PR DESCRIPTION
### Description

This PR fixes a compilation error in Xcode 16 Beta compiling against the tvOS 18 SDK:

`/mamba/mambaSharedFramework/Rapid Parser/RapidParserNewTagCallbacks.h:25:53: Missing '#include <_types/_uint64_t.h>'; 'uint64_t' must be declared before it is used`

### Change Notes

* Added the necessary <stdint.h> import where it is used.

### Pre-submission Checklist

- [X] I ran the unit tests locally before checking in.
- [X] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

