### PR TITLE
Fixed a compilation error on Xcode 16 Beta

### DIFF
--- a/mambaSharedFramework/HLS ObjectiveC/RapidParserNewTagCallbacks.h
+++ b/mambaSharedFramework/HLS ObjectiveC/RapidParserNewTagCallbacks.h
@@ -21,6 +21,7 @@
 #define RapidParserCallback_h
 
 #include <stdbool.h>
+#include <stdint.h>
 
 void NewTagCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName, const uint64_t startTagData, const uint64_t endTagData);
 void NewTagNoDataCallback(const void *parentparser, const uint64_t startTagName, const uint64_t endTagName);

--- a/mambaSharedFramework/HLS ObjectiveC/RapidParserState.h
+++ b/mambaSharedFramework/HLS ObjectiveC/RapidParserState.h
@@ -21,6 +21,7 @@
 #define RapidParserState_h
 
 #include <stdio.h>
+#include <stdint.h>
 
 enum ParseState {
     // normal scanning state

--- a/mambaSharedFramework/HLS ObjectiveC/RapidParserStateHandlers.h
+++ b/mambaSharedFramework/HLS ObjectiveC/RapidParserStateHandlers.h
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include "RapidParserLineState.h"
+#include <stdint.h>
 
 // Type definition of the standard parser handler
 

--- a/mambaSharedFramework/HLS ObjectiveC/include/RapidParserError.h
+++ b/mambaSharedFramework/HLS ObjectiveC/include/RapidParserError.h
@@ -21,6 +21,7 @@
 #define RapidParserError_h
 
 #include <stdio.h>
+#include <stdint.h>
 
 extern const uint32_t RapidParserErrorMissingTagData;
 


### PR DESCRIPTION
## Description

This PR fixes a compilation error in Xcode 16 Beta:
```
/mamba/mambaSharedFramework/Rapid Parser/RapidParserNewTagCallbacks.h:25:53: Missing '#include <_types/_uint64_t.h>'; 'uint64_t' must be declared before it is used
```
## Change Notes

Added the necessary <stdint.h> import where it is used.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [ ] I have written useful documentation for all public code.
- [ ] I have written unit tests for this new feature.

