### PR TITLE
Introduce EXT-X-SKIP support (Targeting version 2.x)

### DIFF
--- a/mambaSharedFramework/Pantos-Generic Playlist Parsing/PantosTag.swift
+++ b/mambaSharedFramework/Pantos-Generic Playlist Parsing/PantosTag.swift
@@ -77,6 +77,7 @@ public enum PantosTag: String {
     
     // MARK: Variant playlist - Media metadata tags
     case EXT_X_DATERANGE = "EXT-X-DATERANGE"
+    case EXT_X_SKIP = "EXT-X-SKIP"
 }
 
 extension PantosTag: PlaylistTagDescriptor, Equatable {
@@ -139,6 +140,8 @@ extension PantosTag: PlaylistTagDescriptor, Equatable {
         case .EXT_X_TARGETDURATION:
             fallthrough
         case .EXT_X_DATERANGE:
+            fallthrough
+        case .EXT_X_SKIP:
             return .wholePlaylist
         
         case .EXT_X_BITRATE:
@@ -204,6 +207,8 @@ extension PantosTag: PlaylistTagDescriptor, Equatable {
         case .EXT_X_KEY:
             fallthrough
         case .EXT_X_DATERANGE:
+            fallthrough
+        case .EXT_X_SKIP:
             return .keyValue
             
         case .Location:
@@ -278,6 +283,8 @@ extension PantosTag: PlaylistTagDescriptor, Equatable {
         case .EXT_X_KEY:
             fallthrough
         case .EXT_X_DATERANGE:
+            fallthrough
+        case .EXT_X_SKIP:
             return GenericDictionaryTagParser(tag: pantostag)
             
         // No Data tags
@@ -342,6 +349,8 @@ extension PantosTag: PlaylistTagDescriptor, Equatable {
         case .EXT_X_KEY:
             fallthrough
         case .EXT_X_DATERANGE:
+            fallthrough
+        case .EXT_X_SKIP:
             return GenericDictionaryTagWriter()
             
         // These tags cannot be modified and therefore these cases are invalid.
@@ -464,7 +473,17 @@ extension PantosTag: PlaylistTagDescriptor, Equatable {
             
         case .EXT_X_DATERANGE:
             return EXT_X_DATERANGETagValidator()
-            
+
+        case .EXT_X_SKIP:
+            return GenericDictionaryTagValidator(tag: pantostag, dictionaryValueIdentifiers: [
+                DictionaryTagValueIdentifierImpl(valueId: PantosValue.skippedSegments,
+                                                 optional: false,
+                                                 expectedType: Int.self),
+                DictionaryTagValueIdentifierImpl(valueId: PantosValue.recentlyRemovedDateranges,
+                                                 optional: true,
+                                                 expectedType: String.self)
+            ])
+
         case .Location:
             return nil
 
@@ -510,7 +529,8 @@ extension PantosTag: PlaylistTagDescriptor, Equatable {
                        PantosTag.EXT_X_START,
                        PantosTag.EXT_X_DISCONTINUITY,
                        PantosTag.EXT_X_BITRATE,
-                       PantosTag.EXT_X_DATERANGE]
+                       PantosTag.EXT_X_DATERANGE,
+                       PantosTag.EXT_X_SKIP]
 
         var dictionary = [UInt: [(descriptor: PantosTag, string: MambaStringRef)]]()
         

--- a/mambaSharedFramework/Pantos-Generic Playlist Parsing/PantosValue.swift
+++ b/mambaSharedFramework/Pantos-Generic Playlist Parsing/PantosValue.swift
@@ -189,7 +189,22 @@ public enum PantosValue: String {
     /// after the START-DATE of the range in question.  This attribute is
     /// OPTIONAL.
     case endOnNext = "END-ON-NEXT"
-    
+
+    /// Found in `.EXT_X_SKIP`.
+    ///
+    /// The value is a decimal-integer specifying the number of Media
+    /// Segments replaced by the EXT-X-SKIP tag.  This attribute is
+    /// REQUIRED.
+    case skippedSegments = "SKIPPED-SEGMENTS"
+
+    /// Found in `.EXT_X_SKIP`.
+    ///
+    /// The value is a quoted-string consisting of a tab (0x9) delimited
+    /// list of EXT-X-DATERANGE IDs that have been removed from the
+    /// Playlist recently.  See Section 6.2.5.1 for more information.
+    /// This attribute is REQUIRED if the Client requested an update that
+    /// skips EXT-X-DATERANGE tags.  The quoted-string MAY be empty.
+    case recentlyRemovedDateranges = "RECENTLY-REMOVED-DATERANGES"
 }
 
 extension PantosValue: PlaylistTagValueIdentifier {

--- a/mambaSharedFramework/Playlist Models/Playlist Structure/PlaylistStructureCore.swift
+++ b/mambaSharedFramework/Playlist Models/Playlist Structure/PlaylistStructureCore.swift
@@ -251,42 +251,42 @@ struct PlaylistStructureConstructor {
         var lastRecordedTime: CMTime = CMTime.invalid
         var currentSegmentDuration: CMTime = CMTime.invalid
         var discontinuity = false
-        
-        // collect indices for media sequence and skip tags as they impact the initial media sequence value
-        var mediaSequenceTagIndices = [Int]()
-        var skipTagIndices = [Int]()
-        tags.enumerated().forEach {
-            switch $0.element.tagDescriptor {
-            case PantosTag.EXT_X_MEDIA_SEQUENCE: mediaSequenceTagIndices.append($0.offset)
-            case PantosTag.EXT_X_SKIP: skipTagIndices.append($0.offset)
-            default: break
+
+        // collect media sequence and skip tag (if they exist) as they impact the initial media sequence value
+        var mediaSequenceTag: PlaylistTag?
+        var skipTag: PlaylistTag?
+        for tag in tags {
+            switch tag.tagDescriptor {
+            case PantosTag.EXT_X_MEDIA_SEQUENCE: mediaSequenceTag = tag
+            case PantosTag.EXT_X_SKIP: skipTag = tag
+            case PantosTag.Location:
+                // Both the EXT-X-MEDIA-SEQUNCE and the EXT-X-SKIP tag are expected to occur before any Media Segments.
+                //
+                // For EXT-X-MEDIA-SEQUNCE section 4.4.3.2 indicates:
+                //     The EXT-X-MEDIA-SEQUENCE tag MUST appear before the first Media Segment in the Playlist.
+                //
+                // For EXT-X-SKIP section 4.4.5.2 indicates:
+                //     A server produces a Playlist Delta Update (Section 6.2.5.1), by replacing tags earlier than the
+                //     Skip Boundary with an EXT-X-SKIP tag. When replacing Media Segments, the EXT-X-SKIP tag replaces
+                //     the segment URI lines and all Media Segment Tags tags that are applied to those segments.
+                //
+                // Exiting early at the first Location helps us avoid having to loop through the entire playlist when we
+                // know that the tags we're looking for MUST NOT exist.
+                break
+            default: continue
             }
         }
 
-        // figure out our media sequence start (defaults to 1 if not specified)
-        if mediaSequenceTagIndices.count > 0 {
-            assert(mediaSequenceTagIndices.count == 1, "Unexpected to have more than one media sequence")
-            if
-                let mediaSequenceIndex = mediaSequenceTagIndices.first,
-                let startMediaSequence: MediaSequence = tags[mediaSequenceIndex].value(
-                    forValueIdentifier: PantosValue.sequence
-                )
-            {
-                currentMediaSequence = startMediaSequence
-            }
+        // figure out our media sequence start (defaults to 0 if not specified)
+        if let startMediaSequence: MediaSequence = mediaSequenceTag?.value(forValueIdentifier: PantosValue.sequence) {
+            currentMediaSequence = startMediaSequence
         }
 
-        // account for any skip tags (since a delta update replaces all segments earlier than the skip boundary, the
+        // account for any skip tag (since a delta update replaces all segments earlier than the skip boundary, the
         // SKIPPED-SEGMENTS value will effectively update the current media sequence value of the first segment, so safe
         // to do this here and not within the looping through media group tags below).
-        if skipTagIndices.count > 0 {
-            assert(skipTagIndices.count == 1, "Unexpected to have more than one skip tag")
-            if
-                let skipTagIndex = skipTagIndices.first,
-                let skippedSegments: Int = tags[skipTagIndex].value(forValueIdentifier: PantosValue.skippedSegments)
-            {
-                currentMediaSequence += skippedSegments
-            }
+        if let skippedSegments: Int = skipTag?.value(forValueIdentifier: PantosValue.skippedSegments) {
+            currentMediaSequence += skippedSegments
         }
         
         // find the "header" portion by finding the first ".mediaSegment" scoped tag

--- a/mambaTests/PantosTagTests.swift
+++ b/mambaTests/PantosTagTests.swift
@@ -43,6 +43,7 @@ class PantosTagTests: XCTestCase {
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_ENDLIST)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_BITRATE)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_DATERANGE)
+        runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_SKIP)
 
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_INDEPENDENT_SEGMENTS)
         runStringRefLookupTest(onPantosDescriptor: PantosTag.EXT_X_START)
@@ -101,6 +102,8 @@ class PantosTagTests: XCTestCase {
         case .EXTINF:
             fallthrough
         case .EXT_X_DATERANGE:
+            fallthrough
+        case .EXT_X_SKIP:
             let stringRef = MambaStringRef(string: "#\(descriptor.toString())")
             guard let newDescriptor = PantosTag.constructDescriptor(fromStringRef: stringRef) else {
                 XCTFail("PantosTag \(descriptor.toString()) is missing from stringRefLookup table.")

--- a/mambaTests/PlaylistStructureAndEditingTests.swift
+++ b/mambaTests/PlaylistStructureAndEditingTests.swift
@@ -997,21 +997,23 @@ let sample4SegmentPlaylist =
 "#EXT-X-ENDLIST\n"
 
 let sampleDeltaUpdatePlaylist =
-    "#EXTM3U\n" +
-        "#EXT-X-VERSION:9\n" +
-        "#EXT-X-MEDIA-SEQUENCE:1\n" +
-        "#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=12\n" +
-        "#EXT-X-TARGETDURATION:2\n" +
-        "#EXT-X-SKIP:SKIPPED-SEGMENTS=4\n" +
-        "#EXTINF:2.002,\n" +
-        "http://not.a.server.nowhere/segment5.ts\n" +
-        "#EXTINF:2.002,\n" +
-        "http://not.a.server.nowhere/segment6.ts\n" +
-        "#EXTINF:2.002,\n" +
-        "http://not.a.server.nowhere/segment7.ts\n" +
-        "#EXTINF:2.002,\n" +
-        "http://not.a.server.nowhere/segment8.ts\n" +
-        "#EXTINF:2.002,\n" +
-        "http://not.a.server.nowhere/segment9.ts\n" +
-        "#EXTINF:2.002,\n" +
-"http://not.a.server.nowhere/segment10.ts\n"
+"""
+#EXTM3U
+#EXT-X-VERSION:9
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=12
+#EXT-X-TARGETDURATION:2
+#EXT-X-SKIP:SKIPPED-SEGMENTS=4
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment5.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment6.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment7.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment8.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment9.ts
+#EXTINF:2.002,
+http://not.a.server.nowhere/segment10.ts
+"""

--- a/mambaTests/PlaylistStructureAndEditingTests.swift
+++ b/mambaTests/PlaylistStructureAndEditingTests.swift
@@ -870,6 +870,26 @@ fragment1.ts
         
         XCTAssertEqual(playlist3.playlistType, .event)
     }
+
+    func testDeltaUpdateCorrectlyCalculatesMediaSequencesInTagGroups() {
+        let playlist = parseVariantPlaylist(inString: sampleDeltaUpdatePlaylist)
+
+        XCTAssertEqual(playlist.header?.range.count, 5, "Should have a header including 'server-control' and 'skip'")
+        XCTAssertEqual(playlist.mediaSegmentGroups.count, 6, "Should have 6 remaining groups")
+        for i in 0..<6 {
+            guard playlist.mediaSegmentGroups.indices.contains(i) else {
+                return XCTFail("Should have media segment group at index \(i)")
+            }
+            let group = playlist.mediaSegmentGroups[i]
+            XCTAssertEqual(
+                group.mediaSequence,
+                i + 5,
+                "Should have media sequence value equal to index (\(i)) + initial media sequence (1) + skipped (4)"
+            )
+        }
+        XCTAssertNil(playlist.footer, "Should have no footer")
+        XCTAssertEqual(playlist.mediaSpans.count, 0, "Should have no spans (no key tags)")
+    }
 }
 
 
@@ -975,3 +995,23 @@ let sample4SegmentPlaylist =
         "#EXTINF:2.002,\n" +
         "http://not.a.server.nowhere/segment4.ts\n" +
 "#EXT-X-ENDLIST\n"
+
+let sampleDeltaUpdatePlaylist =
+    "#EXTM3U\n" +
+        "#EXT-X-VERSION:9\n" +
+        "#EXT-X-MEDIA-SEQUENCE:1\n" +
+        "#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=12\n" +
+        "#EXT-X-TARGETDURATION:2\n" +
+        "#EXT-X-SKIP:SKIPPED-SEGMENTS=4\n" +
+        "#EXTINF:2.002,\n" +
+        "http://not.a.server.nowhere/segment5.ts\n" +
+        "#EXTINF:2.002,\n" +
+        "http://not.a.server.nowhere/segment6.ts\n" +
+        "#EXTINF:2.002,\n" +
+        "http://not.a.server.nowhere/segment7.ts\n" +
+        "#EXTINF:2.002,\n" +
+        "http://not.a.server.nowhere/segment8.ts\n" +
+        "#EXTINF:2.002,\n" +
+        "http://not.a.server.nowhere/segment9.ts\n" +
+        "#EXTINF:2.002,\n" +
+"http://not.a.server.nowhere/segment10.ts\n"

--- a/mambaTests/Tag Validator Tests/GenericDictionaryTagValidatorTests.swift
+++ b/mambaTests/Tag Validator Tests/GenericDictionaryTagValidatorTests.swift
@@ -797,4 +797,46 @@ class GenericDictionaryTagValidatorTests: XCTestCase {
                            "Expected EXT-X-DATERANGE validation issue (\(expectedValidationIssue.description)) had unexpected severity (\(matchingIssue.severity))")
         }
     }
+
+    /*
+     A server produces a Playlist Delta Update (Section 6.2.5.1), by
+     replacing tags earlier than the Skip Boundary with an EXT-X-SKIP tag.
+
+     When replacing Media Segments, the EXT-X-SKIP tag replaces the
+     segment URI lines and all Media Segment Tags tags that are applied to
+     those segments.  This tag MUST NOT appear more than once in a
+     Playlist.
+
+     Its format is:
+
+     #EXT-X-SKIP:<attribute-list>
+
+     The following attributes are defined:
+
+        SKIPPED-SEGMENTS
+
+        The value is a decimal-integer specifying the number of Media
+        Segments replaced by the EXT-X-SKIP tag.  This attribute is
+        REQUIRED.
+
+        RECENTLY-REMOVED-DATERANGES
+
+        The value is a quoted-string consisting of a tab (0x9) delimited
+        list of EXT-X-DATERANGE IDs that have been removed from the
+        Playlist recently.  See Section 6.2.5.1 for more information.
+        This attribute is REQUIRED if the Client requested an update that
+        skips EXT-X-DATERANGE tags.  The quoted-string MAY be empty.
+     */
+    func test_EXT_X_SKIP() {
+        let tagData = "SKIPPED-SEGMENTS=10,RECENTLY-REMOVED-DATERANGES=\"\""
+        let optional: [PantosValue] = [.recentlyRemovedDateranges]
+        let mandatory: [PantosValue] = [.skippedSegments]
+        let badValues: [PantosValue] = [.skippedSegments]
+
+        validate(tag: PantosTag.EXT_X_SKIP,
+                 tagData: tagData,
+                 optional: optional,
+                 mandatory: mandatory,
+                 badValues: badValues)
+    }
 }


### PR DESCRIPTION
### Description

This PR cherry-picks the changes from #130 into a branch based out of `develop` to create a version compatible with version 2 of the library.

### Change Notes

* Added new value (`EXT_X_SKIP`) to the `PantosTag` enum and made the necessary updates for the `HLSTagDescriptor` conformance.
* Added new values to `PantosValue` to account for attributes related to EXT-X-SKIP (`.skippedSegments` and `.recentlyRemovedDateranges`).
* Updated `generateMediaGroups` for `HLSPlaylistStructure` to account for any `SKIPPED-SEGMENTS` when calculating media sequence values for segment tag groups.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

