### PR TITLE
Adding action to build and test iOS and tvOS targets

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,19 +7,28 @@ on:
     branches: [ "develop", "develop_1.x" ]
 
 jobs:
+  define-ios-device:
+    name: Get iOS simulator device to run iOS tests on
+    runs-on: macos-latest
+    outputs:
+      ios_device: ${{ steps.ios.outputs.device }}
+    steps:
+      - id: ios
+        run: echo "device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build and Test mamba and mambaTVOS
     runs-on: macos-latest
+    needs: define-ios-device
     strategy:
       matrix:
         target:
           - scheme: mamba
             platform: iOS Simulator
-            device: ${{ `xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"` }}
+            device: ${{ needs.define-ios-device.outputs.device }}
           - scheme: mambaTVOS
             platform: tvOS Simulator
             device: Apple TV
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,39 @@
+name: Build and test
+
+on:
+  push:
+    branches: [ "develop", "develop_1.x" ]
+  pull_request:
+    branches: [ "develop", "develop_1.x" ]
+
+jobs:
+  build:
+    name: Build and Test mamba and mambaTVOS
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target:
+          - scheme: mamba
+            platform: iOS Simulator
+            device: ${{ `xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"` }}
+          - scheme: mambaTVOS
+            platform: tvOS Simulator
+            device: Apple TV
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        env:
+          scheme: ${{ matrix.target.scheme }}
+          platform: ${{ matrix.target.platform }}
+          device: ${{ matrix.target.device }}
+        run: |
+          xcodebuild build-for-testing -scheme "$scheme" -"workspace" "mamba.xcworkspace" -destination "platform=$platform,name=$device"
+      - name: Test
+        env:
+          scheme: ${{ matrix.target.scheme }}
+          platform: ${{ matrix.target.platform }}
+          device: ${{ matrix.target.device }}
+        run: |
+          xcodebuild test-without-building -scheme "$scheme" -"workspace" "mamba.xcworkspace" -destination "platform=$platform,name=$device"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,10 +1,8 @@
 name: Build and test
 
 on:
-  push:
-    branches: [ "develop", "develop_1.x" ]
   pull_request:
-    branches: [ "develop", "develop_1.x" ]
+    branches: [ "develop", "develop_1.x", "main", "main_1.x" ]
 
 jobs:
   define-ios-device:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Get iOS simulator device to run iOS tests on
     runs-on: macos-latest
     outputs:
-      ios_device: ${{ steps.ios.outputs.device }}
+      device: ${{ steps.ios.outputs.device }}
     steps:
       - id: ios
         run: echo "device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`" >> "$GITHUB_OUTPUT"
@@ -38,6 +38,9 @@ jobs:
           platform: ${{ matrix.target.platform }}
           device: ${{ matrix.target.device }}
         run: |
+          echo "scheme = $scheme"
+          echo "platform = $platform"
+          echo "device = $device"
           xcodebuild build-for-testing -scheme "$scheme" -"workspace" "mamba.xcworkspace" -destination "platform=$platform,name=$device"
       - name: Test
         env:
@@ -45,4 +48,7 @@ jobs:
           platform: ${{ matrix.target.platform }}
           device: ${{ matrix.target.device }}
         run: |
+          echo "scheme = $scheme"
+          echo "platform = $platform"
+          echo "device = $device"
           xcodebuild test-without-building -scheme "$scheme" -"workspace" "mamba.xcworkspace" -destination "platform=$platform,name=$device"


### PR DESCRIPTION
### Description

This PR attempts to introduce GitHub Actions to the repo to cover basic build and test validation for further PRs into `develop` and `develop_1.x`. The iOS and tvOS targets are tested here for now. I need to look up what commands make sense to test for macOS (if we want to add that).

### Change Notes

* Introduced `.github/workflows/build-and-test.yml` to enable GitHub Actions integration.
* Added test steps for iOS and tvOS targets.

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.

