### PR TITLE
Interstitial tag support Mamba 2.0

### DIFF
--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		E65FB24A2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */; };
 		E65FB24B2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */; };
 		E65FB24C2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */; };
+		E65FB24E2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB24D2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift */; };
+		E65FB24F2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB24D2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift */; };
+		E65FB2502CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB24D2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift */; };
 		EC03B63D1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63E1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63F1E5CC55800BF1F97 /* RapidParserMasterParseArray.h in Headers */ = {isa = PBXBuildFile; fileRef = EC03B63C1E5CC55800BF1F97 /* RapidParserMasterParseArray.h */; };
@@ -682,6 +685,7 @@
 		E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTypes.swift; sourceTree = "<group>"; };
 		E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTests.swift; sourceTree = "<group>"; };
 		E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialTagBuilder.swift; sourceTree = "<group>"; };
+		E65FB24D2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialTagBuilderTests.swift; sourceTree = "<group>"; };
 		EC03B62D1E5CC54900BF1F97 /* PrototypeRapidParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = PrototypeRapidParseArray.include; sourceTree = "<group>"; };
 		EC03B62E1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTINFState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTINFState_ParseArray.include; sourceTree = "<group>"; };
 		EC03B62F1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTState_ParseArray.include; sourceTree = "<group>"; };
@@ -1337,6 +1341,7 @@
 				EC073F5F1FE08F7500689228 /* String+Helio.swift */,
 				EC7492A61DD29F7000AF4E20 /* URLSchemeChangeTests.swift */,
 				EC9BCAA21D749D8B0032BEBE /* Value Types */,
+				E65FB24D2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift */,
 			);
 			path = "Util Tests";
 			sourceTree = "<group>";
@@ -1927,6 +1932,7 @@
 				EC7492761DD29EC800AF4E20 /* EXT_X_KEYTagParserTests.swift in Sources */,
 				883290561EA172170064588B /* MambaStringRefExtensionTests.swift in Sources */,
 				ECDE185122387257008566BB /* VariantPlaylistMediaSpanTests.swift in Sources */,
+				E65FB2502CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift in Sources */,
 				EC7492A91DD29F7000AF4E20 /* MambaUtilTests.swift in Sources */,
 				EC7492741DD29EC800AF4E20 /* EXT_X_I_FRAME_STREAM_INFTagParserTests.swift in Sources */,
 				ECFBD90E1E5CCC2200379FC2 /* MambaStringRefTests.m in Sources */,
@@ -2107,6 +2113,7 @@
 				EC7492291DD29E4A00AF4E20 /* FixtureLoader.swift in Sources */,
 				F7CFF27F1F392009009F4C82 /* CMTimeMakeFromStringTests.swift in Sources */,
 				ECDE185222387257008566BB /* VariantPlaylistMediaSpanTests.swift in Sources */,
+				E65FB24F2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift in Sources */,
 				EC7492771DD29EC800AF4E20 /* EXT_X_KEYTagParserTests.swift in Sources */,
 				EC7492AA1DD29F7000AF4E20 /* MambaUtilTests.swift in Sources */,
 				ECFBD90F1E5CCC2200379FC2 /* MambaStringRefTests.m in Sources */,
@@ -2287,6 +2294,7 @@
 				ECE253F0209A50B500D388CE /* EXT_X_I_FRAME_STREAM_INFTagParserTests.swift in Sources */,
 				ECDE185322387257008566BB /* VariantPlaylistMediaSpanTests.swift in Sources */,
 				ECE25405209A50B500D388CE /* CodecArrayTests.swift in Sources */,
+				E65FB24E2CD526DD00BF6F56 /* InterstitialTagBuilderTests.swift in Sources */,
 				ECE253EA209A50A100D388CE /* MambaStringRefTests.m in Sources */,
 				ECE253F7209A50B500D388CE /* StringArrayParserTests.swift in Sources */,
 				ECE25401209A50B500D388CE /* MambaUtilTests.swift in Sources */,

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -58,6 +58,9 @@
 		D44E03781E3BAC9F00126B52 /* PlaylistTag+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44E03761E3BAC9F00126B52 /* PlaylistTag+Util.swift */; };
 		D4BB018D1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BB018C1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift */; };
 		D4BB018E1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BB018C1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift */; };
+		E65FB2422CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */; };
+		E65FB2432CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */; };
+		E65FB2442CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */; };
 		EC03B63D1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63E1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63F1E5CC55800BF1F97 /* RapidParserMasterParseArray.h in Headers */ = {isa = PBXBuildFile; fileRef = EC03B63C1E5CC55800BF1F97 /* RapidParserMasterParseArray.h */; };
@@ -670,6 +673,7 @@
 		883290551EA172170064588B /* MambaStringRefExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MambaStringRefExtensionTests.swift; sourceTree = "<group>"; };
 		D44E03761E3BAC9F00126B52 /* PlaylistTag+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlaylistTag+Util.swift"; sourceTree = "<group>"; };
 		D4BB018C1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlaylistTagArray+RenditionGroups.swift"; sourceTree = "<group>"; };
+		E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTypes.swift; sourceTree = "<group>"; };
 		EC03B62D1E5CC54900BF1F97 /* PrototypeRapidParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = PrototypeRapidParseArray.include; sourceTree = "<group>"; };
 		EC03B62E1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTINFState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTINFState_ParseArray.include; sourceTree = "<group>"; };
 		EC03B62F1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTState_ParseArray.include; sourceTree = "<group>"; };
@@ -1109,6 +1113,7 @@
 				EC03B62B1E5CC51C00BF1F97 /* Rapid Parser */,
 				EC7ECA011D30177A000EEB7D /* Utils */,
 				EC7491B11DD29D5C00AF4E20 /* ValueTypes.swift */,
+				E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */,
 			);
 			path = mambaSharedFramework;
 			sourceTree = "<group>";
@@ -1871,6 +1876,7 @@
 				EC676A7822B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */,
 				EC7491461DD299B400AF4E20 /* PlaylistTypes.swift in Sources */,
 				EC349ACE2236C3A60077432B /* PlaylistStructureInterface.swift in Sources */,
+				E65FB2432CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */,
 				EC3B01A71DD4D47900B512E3 /* EXT_X_MEDIARenditionGroupAUTOSELECTValidator.swift in Sources */,
 				F700CD391E78A2BE001C9487 /* MambaStringRef_ConcreteNSString.m in Sources */,
 				144758312C83C72B00D12CCD /* EXT_X_SESSION_DATATagValidator.swift in Sources */,
@@ -2048,6 +2054,7 @@
 				EC676A7922B05BF0008920BB /* MasterPlaylistStreamSummary.swift in Sources */,
 				EC7491661DD29B0F00AF4E20 /* FailableStringLiteralConvertible.swift in Sources */,
 				EC349ACF2236C3A60077432B /* PlaylistStructureInterface.swift in Sources */,
+				E65FB2442CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */,
 				EC7491471DD299B400AF4E20 /* PlaylistTypes.swift in Sources */,
 				F700CD3A1E78A2BE001C9487 /* MambaStringRef_ConcreteNSString.m in Sources */,
 				144758322C83C72B00D12CCD /* EXT_X_SESSION_DATATagValidator.swift in Sources */,
@@ -2225,6 +2232,7 @@
 				EC1CCD4F209A2CF9006B59FF /* PlaylistTagCardinalityValidation.swift in Sources */,
 				EC1CCD2B209A2CF9006B59FF /* IndeterminateBool.swift in Sources */,
 				EC349AD02236C3A60077432B /* PlaylistStructureInterface.swift in Sources */,
+				E65FB2422CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */,
 				144758332C83C72B00D12CCD /* EXT_X_SESSION_DATATagValidator.swift in Sources */,
 				EC1CCD43209A2CF9006B59FF /* EXT_X_STREAM_INFRenditionGroupValidator.swift in Sources */,
 				1447582F2C83C20800D12CCD /* EXT_X_SESSION_KEYValidator.swift in Sources */,

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		E65FB2422CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */; };
 		E65FB2432CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */; };
 		E65FB2442CD51E4200BF6F56 /* InterstitialValueTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */; };
+		E65FB2462CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */; };
+		E65FB2472CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */; };
+		E65FB2482CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */; };
 		EC03B63D1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63E1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63F1E5CC55800BF1F97 /* RapidParserMasterParseArray.h in Headers */ = {isa = PBXBuildFile; fileRef = EC03B63C1E5CC55800BF1F97 /* RapidParserMasterParseArray.h */; };
@@ -674,6 +677,7 @@
 		D44E03761E3BAC9F00126B52 /* PlaylistTag+Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlaylistTag+Util.swift"; sourceTree = "<group>"; };
 		D4BB018C1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlaylistTagArray+RenditionGroups.swift"; sourceTree = "<group>"; };
 		E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTypes.swift; sourceTree = "<group>"; };
+		E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTests.swift; sourceTree = "<group>"; };
 		EC03B62D1E5CC54900BF1F97 /* PrototypeRapidParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = PrototypeRapidParseArray.include; sourceTree = "<group>"; };
 		EC03B62E1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTINFState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTINFState_ParseArray.include; sourceTree = "<group>"; };
 		EC03B62F1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTState_ParseArray.include; sourceTree = "<group>"; };
@@ -1352,6 +1356,7 @@
 				EC7492B11DD29F8900AF4E20 /* PlaylistTypeTests.swift */,
 				EC7492B21DD29F8900AF4E20 /* ResolutionTests.swift */,
 				1447583C2C8693E000D12CCD /* VideoLayoutTests.swift */,
+				E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */,
 			);
 			path = "Value Types";
 			sourceTree = "<group>";
@@ -1946,6 +1951,7 @@
 				EC7492AD1DD29F7000AF4E20 /* URLSchemeChangeTests.swift in Sources */,
 				ECFBD9031E5CCAAF00379FC2 /* XCTestCase+mamba.swift in Sources */,
 				EC7492A11DD29F4600AF4E20 /* ThirdPartyTagListSupportTests.swift in Sources */,
+				E65FB2472CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */,
 				3D933C1A2193367C0029069F /* EXT-X-BITRATETagParserTests.swift in Sources */,
 				EC073F5D1FE0840000689228 /* OutputStreamExtensionTests.swift in Sources */,
 				ECC410671EA1527700B4E3C8 /* PlaylistTagGroupTests.swift in Sources */,
@@ -2124,6 +2130,7 @@
 				ECBEF4F21F7AC58A0051078F /* ReadMeUnitTests.swift in Sources */,
 				EC7492851DD29EC800AF4E20 /* StringDictionaryParserTests.swift in Sources */,
 				EC7492AE1DD29F7000AF4E20 /* URLSchemeChangeTests.swift in Sources */,
+				E65FB2462CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */,
 				3D933C1C219336970029069F /* EXT-X-BITRATETagParserTests.swift in Sources */,
 				ECFBD9041E5CCAAF00379FC2 /* XCTestCase+mamba.swift in Sources */,
 				EC073F5E1FE0840000689228 /* OutputStreamExtensionTests.swift in Sources */,
@@ -2302,6 +2309,7 @@
 				ECE253EB209A50A100D388CE /* ParseArrayTests.m in Sources */,
 				ECE253E5209A509900D388CE /* TagWriting.swift in Sources */,
 				3D933C1B219336970029069F /* EXT-X-BITRATETagParserTests.swift in Sources */,
+				E65FB2482CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */,
 				ECE253F5209A50B500D388CE /* GenericNoDataTagParserTests.swift in Sources */,
 				ECE253D4209A509000D388CE /* TagParserMock.swift in Sources */,
 				ECE253E3209A509900D388CE /* PlaylistTagGroupTests.swift in Sources */,

--- a/mamba.xcodeproj/project.pbxproj
+++ b/mamba.xcodeproj/project.pbxproj
@@ -64,6 +64,9 @@
 		E65FB2462CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */; };
 		E65FB2472CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */; };
 		E65FB2482CD5241D00BF6F56 /* InterstitialValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */; };
+		E65FB24A2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */; };
+		E65FB24B2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */; };
+		E65FB24C2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */; };
 		EC03B63D1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63E1E5CC55800BF1F97 /* RapidParserMasterParseArray.c in Sources */ = {isa = PBXBuildFile; fileRef = EC03B63B1E5CC55800BF1F97 /* RapidParserMasterParseArray.c */; };
 		EC03B63F1E5CC55800BF1F97 /* RapidParserMasterParseArray.h in Headers */ = {isa = PBXBuildFile; fileRef = EC03B63C1E5CC55800BF1F97 /* RapidParserMasterParseArray.h */; };
@@ -678,6 +681,7 @@
 		D4BB018C1E2EABD500CA006E /* PlaylistTagArray+RenditionGroups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PlaylistTagArray+RenditionGroups.swift"; sourceTree = "<group>"; };
 		E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTypes.swift; sourceTree = "<group>"; };
 		E65FB2452CD5241D00BF6F56 /* InterstitialValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialValueTests.swift; sourceTree = "<group>"; };
+		E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterstitialTagBuilder.swift; sourceTree = "<group>"; };
 		EC03B62D1E5CC54900BF1F97 /* PrototypeRapidParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = PrototypeRapidParseArray.include; sourceTree = "<group>"; };
 		EC03B62E1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTINFState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTINFState_ParseArray.include; sourceTree = "<group>"; };
 		EC03B62F1E5CC54900BF1F97 /* RapidParser_LookingForEForEXTState_ParseArray.include */ = {isa = PBXFileReference; lastKnownFileType = text; path = RapidParser_LookingForEForEXTState_ParseArray.include; sourceTree = "<group>"; };
@@ -1118,6 +1122,7 @@
 				EC7ECA011D30177A000EEB7D /* Utils */,
 				EC7491B11DD29D5C00AF4E20 /* ValueTypes.swift */,
 				E65FB2412CD51E4200BF6F56 /* InterstitialValueTypes.swift */,
+				E65FB2492CD524BF00BF6F56 /* InterstitialTagBuilder.swift */,
 			);
 			path = mambaSharedFramework;
 			sourceTree = "<group>";
@@ -1816,6 +1821,7 @@
 				EC349AD62236F55F0077432B /* MasterPlaylistStructure.swift in Sources */,
 				ECDE18442238114E008566BB /* VariantPlaylist.swift in Sources */,
 				EC7491721DD29B5D00AF4E20 /* OrderedDictionary.swift in Sources */,
+				E65FB24A2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */,
 				EC3B01BF1DD4D49A00B512E3 /* PlaylistTagCardinalityValidator.swift in Sources */,
 				EC7491FA1DD29DD300AF4E20 /* GenericSingleTagValidator.swift in Sources */,
 				EC9547851E5CC83C00962535 /* NoOpTagParser.swift in Sources */,
@@ -1995,6 +2001,7 @@
 				EC349AD72236F55F0077432B /* MasterPlaylistStructure.swift in Sources */,
 				ECDE18452238114E008566BB /* VariantPlaylist.swift in Sources */,
 				EC7491CA1DD29D5C00AF4E20 /* PlaylistWriter.swift in Sources */,
+				E65FB24C2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */,
 				EC3B01A61DD4D47900B512E3 /* EXT_X_KEYValidator.swift in Sources */,
 				EC7491731DD29B5D00AF4E20 /* OrderedDictionary.swift in Sources */,
 				EC3B01C01DD4D49A00B512E3 /* PlaylistTagCardinalityValidator.swift in Sources */,
@@ -2174,6 +2181,7 @@
 				EC1CCD60209A2CF9006B59FF /* PlaylistValidationIssue.swift in Sources */,
 				EC349AD82236F55F0077432B /* MasterPlaylistStructure.swift in Sources */,
 				ECDE18462238114E008566BB /* VariantPlaylist.swift in Sources */,
+				E65FB24B2CD524BF00BF6F56 /* InterstitialTagBuilder.swift in Sources */,
 				EC1CCD40209A2CF9006B59FF /* EXT_X_MEDIARenditionGroupTYPEValidator.swift in Sources */,
 				EC1CCD21209A2CF9006B59FF /* RapidParserStateHandlers.c in Sources */,
 				EC1CCD23209A2CF9006B59FF /* CollectionType+FindExtensions.swift in Sources */,

--- a/mambaSharedFramework/InterstitialTagBuilder.swift
+++ b/mambaSharedFramework/InterstitialTagBuilder.swift
@@ -2,7 +2,7 @@
 //  InterstitialTagBuilder.swift
 //  mamba
 //
-//  Created by Migneco, Ray on 11/1/24.
+//  Created by Migneco, Ray on 10/22/24.
 //  Copyright © 2024 Comcast Corporation.
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -18,3 +18,295 @@
 //
 
 import Foundation
+
+/// A utility class for configuring and constructing an interstitial tag
+/// The properties in this class are in accordance with the HLS spec
+/// outlined in `draft-pantos-hls-rfc8216bis-15` Appendix D
+/// https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#appendix-D
+public final class InterstitialTagBuilder {
+
+    /// An Interstitial EXT-X-DATERANGE tag MUST have a CLASS attribute whose
+    /// value is "com.apple.hls.interstitial".
+    static let appleHLSInterstitialClassIdentifier = "com.apple.hls.interstitial"
+
+    /// A quoted-string that uniquely identifies a Date Range in the
+    /// Playlist.  This attribute is REQUIRED
+    let id: String
+
+    /// required to be "com.apple.hls.interstitial"
+    let classId: String
+
+    /// date/time at which the Date Range begins.  This attribute is REQUIRED.
+    let startDate: Date
+
+    /// The value of the X-ASSET-URI is a quoted-string absolute URI for a
+    /// single interstitial asset.  An Interstitial EXT-X-DATERANGE tag
+    /// MUST have either the X-ASSET-URI attribute or the X-ASSET-LIST
+    /// attribute.  It MUST NOT have both.
+    let assetUri: String?
+
+    /// The value of the X-ASSET-LIST is a quoted-string URI to a JSON
+    /// object.
+    let assetList: String?
+
+    /// the duration of the interstitial content in seconds
+    var duration: Double?
+
+    /// the expected duration of the interstitial content in seconds which can indicate a value when the actual duration is not yet known
+    var plannedDuration: Double?
+
+    /// The value of X-RESUME-OFFSET is a decimal-floating-point of seconds that specifies where primary playback is to resume
+    /// following the playback of the interstitial.
+    var resumeOffset: Double?
+
+    /// The value of X-PLAYOUT-LIMIT is a decimal-floating-point of seconds that specifies a limit for the playout time of the entire interstitial.
+    var playoutLimit: Double?
+
+    /// The value of the X-SNAP attribute is an enumerated-string-list of Snap Identifiers.
+    /// The defined Snap Identifiers are: OUT and IN. This attribute is OPTIONAL.
+    var alignment: HLSInterstitialAlignment?
+
+    /// The value of the X-RESTRICT attribute is an enumerated-string-list of Navigation Restriction Identifiers.  The defined Navigation
+    /// Restriction Identifiers are: SKIP and JUMP.  These restrictions are enforced at the player UI level.
+    var restrictions: HLSInterstitialSeekRestrictions?
+
+    /// This attribute indicates whether the interstitial is intended to be presented as distinct from the content ("HIGHLIGHT") or not differentiated ("PRIMARY").
+    var timelineStyle: HLSInterstitialTimelineStyle?
+
+    /// The attribute indicates whether the interstitial should be presented as a single point on the timeline or as a range.
+    var timelineOccupation: HLSInterstitialTimelineOccupation?
+
+    /// Provides a hint to the client to know how coordinated playback of the same asset will behave across multiple players
+    var contentMayVary: Bool?
+
+    /// The "X-" prefix defines a namespace reserved for client-defined attributes.  The client-attribute MUST be a legal AttributeName.
+    /// Clients SHOULD use a reverse-DNS syntax when defining their own attribute names to avoid collisions.  The attribute value MUST be
+    /// a quoted-string, a hexadecimal-sequence, or a decimal-floating- point.  An example of a client-defined attribute is X-COM-EXAMPLE-
+    /// AD-ID="XYZ123".  These attributes are OPTIONAL.
+    var clientAttributes: [String: LosslessStringConvertible]?
+
+    /// Creates a Tag Builder using an asset Uri
+    ///
+    /// - Parameters:
+    ///   - id: the identifier for the interstitial
+    ///   - startDate: `Date` at which the interstitial begins
+    ///   - assetUri: the URI locating the interstitial
+    public init(id: String, startDate: Date, assetUri: String) {
+        self.id = id
+        self.startDate = startDate
+        self.assetUri = assetUri
+        self.assetList = nil
+        self.classId = Self.appleHLSInterstitialClassIdentifier
+    }
+
+    /// Creates a Tag Builder using an Asset List Uri
+    ///
+    /// - Parameters:
+    ///   - id: the identifier for the interstitial
+    ///   - startDate: `Date` indicating when the interstitial begins
+    ///   - assetList: the URI to a JSON object containing the assets
+    public init(id: String, startDate: Date, assetList: String) {
+        self.id = id
+        self.startDate = startDate
+        self.assetList = assetList
+        self.assetUri = nil
+        self.classId = Self.appleHLSInterstitialClassIdentifier
+    }
+
+    /// Specifies the duration of the interstitial
+    ///
+    /// - Parameter duration: `Double` indicating duration
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withDuration(_ duration: Double) -> Self {
+        self.duration = duration
+
+        return self
+    }
+
+    /// Specifies the planned duration of the interstitial
+    ///
+    /// - Parameter duration: `Double` indicating duration
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withPlannedDuration(_ plannedDuration: Double) -> Self {
+        self.plannedDuration = plannedDuration
+
+        return self
+    }
+
+    /// Configures the interstitial with a resume offset
+    ///
+    /// - Parameter offset: `Double` indicating the resume offset
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withResumeOffset(_ offset: Double) -> Self {
+        self.resumeOffset = offset
+
+        return self
+    }
+
+    /// Configures the interstitial with a playout limit
+    ///
+    /// - Parameter limit: `Double` indicating playout limit
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withPlayoutLimit(_ limit: Double) -> Self {
+        self.playoutLimit = limit
+
+        return self
+    }
+
+    /// Specifies the alignment of the interstitial with respect to content
+    ///
+    /// - Parameter alignment: `HLSInterstitialAlignment` specifying alignment guides
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withAlignment(_ alignment: HLSInterstitialAlignment) -> Self {
+        self.alignment = alignment
+
+        return self
+    }
+
+    /// Specifies seek restrictions applied to the interstitial
+    ///
+    /// - Parameter restrictions: instance of `HLSInterstitialSeekRestrictions`
+    ///
+    /// - Returns: an instance of the builder
+    public func withRestrictions(_ restrictions: HLSInterstitialSeekRestrictions) -> Self {
+        self.restrictions = restrictions
+
+        return self
+    }
+
+    /// Specifies how the interstitial is styled on the timeline
+    ///
+    /// - Parameter style: `HLSInterstitialTimelineStyle` type
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withTimelineStyle(_ style: HLSInterstitialTimelineStyle) -> Self {
+        self.timelineStyle = style
+
+        return self
+    }
+
+    /// Describes how the interstitial occupies the content timeline
+    ///
+    /// - Parameter occupation: `HLSInterstitialTimelineOccupation` type
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withTimelineOccupation(_ occupation: HLSInterstitialTimelineOccupation) -> Self {
+        self.timelineOccupation = occupation
+
+        return self
+    }
+
+    /// Indicates if the interstitial content varies or stays the same during a shared watching activity
+    ///
+    /// - Parameter variation: `Bool` indicating if there's variation
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withContentVariation(_ variation: Bool) -> Self {
+        self.contentMayVary = variation
+
+        return self
+    }
+
+    /// Specifies client attributes describing the interstitial
+    ///
+    /// - Parameter attributes: a map of `[String: LosslessStringConvertible]` describing the attributes
+    ///
+    /// - Returns: an instance of the builder
+    @discardableResult
+    public func withClientAttributes(_ attributes: [String: LosslessStringConvertible]) -> Self {
+        self.clientAttributes = attributes
+
+        return self
+    }
+
+    /// Builds the DateRange tag utilizing the configured HLS interstitial properties
+    ///
+    /// - Returns: `PlaylistTag`
+    public func buildTag() -> PlaylistTag {
+
+        var tagDictionary = PlaylistTagDictionary()
+
+        tagDictionary[PantosValue.id.rawValue] = PlaylistTagValueData(value: id, quoteEscaped: true)
+        let startDateString = String.DateFormatter.iso8601MS.string(from: startDate)
+        tagDictionary[PantosValue.startDate.rawValue] = PlaylistTagValueData(value: startDateString,
+                                                                        quoteEscaped: true)
+        tagDictionary[PantosValue.classAttribute.rawValue] = PlaylistTagValueData(value: classId,
+                                                                             quoteEscaped: true)
+
+        if let assetUri {
+            tagDictionary[PantosValue.assetUri.rawValue] = PlaylistTagValueData(value: assetUri, quoteEscaped: true)
+        }
+
+        if let assetList {
+            tagDictionary[PantosValue.assetList.rawValue] = PlaylistTagValueData(value: assetList, quoteEscaped: true)
+        }
+
+        if let duration {
+            tagDictionary[PantosValue.duration.rawValue] = PlaylistTagValueData(value: String(duration),
+                                                                           quoteEscaped: false)
+        }
+
+        if let plannedDuration {
+            tagDictionary[PantosValue.plannedDuration.rawValue] = PlaylistTagValueData(value: String(plannedDuration),
+                                                                                  quoteEscaped: false)
+        }
+
+        if let resumeOffset {
+            tagDictionary[PantosValue.resumeOffset.rawValue] = PlaylistTagValueData(value: String(resumeOffset),
+                                                                               quoteEscaped: false)
+        }
+
+        if let playoutLimit {
+            tagDictionary[PantosValue.playoutLimit.rawValue] = PlaylistTagValueData(value: String(playoutLimit),
+                                                                               quoteEscaped: false)
+        }
+
+        if let restrictions {
+            let str = restrictions.restrictions.map({ $0.rawValue }).joined(separator: ",")
+            tagDictionary[PantosValue.restrict.rawValue] = PlaylistTagValueData(value: str, quoteEscaped: true)
+        }
+
+        if let alignment {
+            let str = alignment.values.map({ $0.rawValue }).joined(separator: ",")
+            tagDictionary[PantosValue.snap.rawValue] = PlaylistTagValueData(value: str, quoteEscaped: true)
+        }
+
+        if let timelineStyle {
+            tagDictionary[PantosValue.timelineStyle.rawValue] = PlaylistTagValueData(value: timelineStyle.rawValue,
+                                                                                quoteEscaped: true)
+        }
+
+        if let timelineOccupation {
+            tagDictionary[PantosValue.timelineOccupies.rawValue] = PlaylistTagValueData(value: timelineOccupation.rawValue,
+                                                                                   quoteEscaped: true)
+        }
+
+        if let contentMayVary {
+            tagDictionary[PantosValue.contentMayVary.rawValue] = PlaylistTagValueData(value: contentMayVary == true ? "YES" : "NO",
+                                                                                 quoteEscaped: true)
+        }
+
+        if let clientAttributes {
+            for (k, v) in clientAttributes {
+                tagDictionary[k] = PlaylistTagValueData(value: String(v), quoteEscaped: true)
+            }
+        }
+
+        return PlaylistTag(tagDescriptor: PantosTag.EXT_X_DATERANGE,
+                      stringTagData: nil,
+                      parsedValues: tagDictionary)
+    }
+}

--- a/mambaSharedFramework/InterstitialTagBuilder.swift
+++ b/mambaSharedFramework/InterstitialTagBuilder.swift
@@ -1,0 +1,20 @@
+//
+//  InterstitialTagBuilder.swift
+//  mamba
+//
+//  Created by Migneco, Ray on 11/1/24.
+//  Copyright © 2024 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import Foundation

--- a/mambaSharedFramework/InterstitialValueTypes.swift
+++ b/mambaSharedFramework/InterstitialValueTypes.swift
@@ -1,0 +1,124 @@
+//
+//  InterstitialValueTypes.swift
+//  mamba
+//
+//  Created by Migneco, Ray on 11/1/24.
+//  Copyright © 2024 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import Foundation
+
+/// specifies how the client should align interstitial content to the primary content
+public struct HLSInterstitialAlignment: FailableStringLiteralConvertible, Equatable {
+
+    public enum Snap: String, CaseIterable {
+        /// client SHOULD locate the segment boundary closest to the scheduled resumption point from the
+        /// interstitial in the Media Playlist of the primary content and resume playback of primary content at that boundary.
+        case `in` = "IN"
+        
+        /// client SHOULD locate the segment boundary closest to the START-DATE of the interstitial in the
+        /// Media Playlist of the primary content and transition to the interstitial at that boundary.
+        case out = "OUT"
+    }
+    
+    /// the set of snap options for aligning interstitial content
+    public let values: Set<Snap>
+    
+    /// creates a snap guide based on provided values
+    ///
+    /// - Parameter values: array of `Snap` values
+    public init(values: [Snap]) {
+        self.values = Set(values)
+    }
+    
+    /// creates a snap guide based on the provided string value
+    ///
+    /// - Parameter string: a comma separated string indicating snap values
+    public init?(failableInitWithString string: String) {
+        let snapValues = string.components(separatedBy: ",")
+            .compactMap({ Snap(rawValue: $0 )})
+        
+        guard !snapValues.isEmpty else { return nil }
+        
+        self.init(values: snapValues)
+    }
+}
+
+/// specifies how the player should enforce seek restrictions for the interstitial content
+public struct HLSInterstitialSeekRestrictions: FailableStringLiteralConvertible, Equatable {
+    
+    public enum Restriction: String, CaseIterable {
+        /// If the list contains SKIP then while the interstitial is being played, the client MUST NOT
+        /// allow the user to seek forward from the current playhead position or set the rate to
+        /// greater than the regular playback rate until playback reaches the end of the interstitial.
+        case skip = "SKIP"
+        
+        /// If the list contains JUMP then the client MUST NOT allow the user to seek from a position
+        /// in the primary asset earlier than the START-DATE attribute to a position after it without
+        /// first playing the interstitial asset, even if the interstitial at START-DATE was played
+        /// through earlier.
+        case jump = "JUMP"
+    }
+    
+    /// set of restrictions applied to the interstitial content
+    public let restrictions: Set<Restriction>
+    
+    /// Creates a set of restrictions based on provided values
+    ///
+    /// - Parameter restrictions: array of `Restriction`
+    public init(restrictions: [Restriction]) {
+        self.restrictions = Set(restrictions)
+    }
+    
+    /// creates a snap guide based on the provided string value
+    ///
+    /// - Parameter string: a comma separated string indicating snap values
+    public init?(failableInitWithString string: String) {
+        let restrictions = string.components(separatedBy: ",")
+            .compactMap({ Restriction(rawValue: $0 )})
+        
+        guard !restrictions.isEmpty else { return nil }
+        
+        self.init(restrictions: restrictions)
+    }
+}
+
+public enum HLSInterstitialTimelineStyle: String, FailableStringLiteralConvertible {
+    
+    /// indicates whether the interstitial is intended to be presented as distinct from the content
+    case highlight = "HIGHLIGHT"
+    
+    /// indicates that the interstitial should NOT be presented as differentiated from the content
+    case primary = "PRIMARY"
+    
+    /// Creates a timeline style from the provided string
+    public init?(failableInitWithString string: String) {
+        self.init(rawValue: string)
+    }
+}
+
+/// Type that indicates how an interstitial event should be presented on a timeline
+public enum HLSInterstitialTimelineOccupation: String, FailableStringLiteralConvertible {
+    
+    /// the interstitial should be presented as a single point on the timeline
+    case point = "POINT"
+    
+    /// the interstitial should be presented as a range on the timeline
+    case range = "RANGE"
+    
+    /// Creates a timeline occupation from the provided string
+    public init?(failableInitWithString string: String) {
+        self.init(rawValue: string)
+    }
+}

--- a/mambaSharedFramework/Pantos-Generic Playlist Parsing/PantosValue.swift
+++ b/mambaSharedFramework/Pantos-Generic Playlist Parsing/PantosValue.swift
@@ -248,6 +248,118 @@ public enum PantosValue: String {
     /// after the START-DATE of the range in question.  This attribute is
     /// OPTIONAL.
     case endOnNext = "END-ON-NEXT"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// The value of the X-ASSET-URI is a quoted-string absolute URI for a
+    /// single interstitial asset.  An Interstitial EXT-X-DATERANGE tag
+    /// MUST have either the X-ASSET-URI attribute or the X-ASSET-LIST
+    /// attribute.  It MUST NOT have both.
+     case assetUri = "X-ASSET-URI"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// The value of the X-ASSET-LIST is a quoted-string URI to a JSON
+    /// object.
+    case assetList = "X-ASSET-LIST"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// The value of X-RESUME-OFFSET is a decimal-floating-point of
+    /// seconds that specifies where primary playback is to resume
+    /// following the playback of the interstitial.  It is expressed as a
+    /// time offset from where the interstitial playback was scheduled on
+    /// the primary player timeline.  A typical value for X-RESUME-OFFSET
+    /// is zero.  This attribute is OPTIONAL.
+    ///
+    /// If the X-RESUME-OFFSET is not present, its value is considered to
+    /// be the duration of the interstitial.  This is appropriate for live
+    /// content, where playback is to be kept at a constant delay from the
+    /// live edge, or for VOD playback where the HLS interstitial is
+    /// intended to exactly replace content in the primary asset.
+     case resumeOffset = "X-RESUME-OFFSET"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// The value of X-PLAYOUT-LIMIT is a decimal-floating-point of
+    /// seconds that specifies a limit for the playout time of the entire
+    /// interstitial.  If it is present, the client SHOULD end the
+    /// interstitial if playback reaches that offset from its start.
+    /// Otherwise the interstitial MUST end upon reaching the end of the
+    /// interstitial asset(s).  This attribute is OPTIONAL.
+    case playoutLimit = "X-PLAYOUT-LIMIT"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// The value of the X-SNAP attribute is an enumerated-string-list of
+    /// Snap Identifiers.  The defined Snap Identifiers are: OUT and IN.
+    /// This attribute is OPTIONAL.
+    ///
+    /// If the list contains OUT then the client SHOULD locate the segment
+    /// boundary closest to the START-DATE of the interstitial in the
+    /// Media Playlist of the primary content and transition to the
+    /// interstitial at that boundary.  If more than one Media Playlist is
+    /// contributing to playback (audio plus video for example), the
+    /// client SHOULD transition at the earliest segment boundary.
+    ///
+    /// If the list contains IN then the client SHOULD locate the segment
+    /// boundary closest to the scheduled resumption point from the
+    /// interstitial in the Media Playlist of the primary content and
+    /// resume playback of primary content at that boundary.  If more than
+    /// one Media Playlist is contributing to playback, the client SHOULD
+    /// transition at the latest segment boundary.
+    case snap = "X-SNAP"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// The value of the X-RESTRICT attribute is an enumerated-string-list
+    /// of Navigation Restriction Identifiers.  The defined Navigation
+    /// Restriction Identifiers are: SKIP and JUMP.  These restrictions
+    /// are enforced at the player UI level.  This attribute is OPTIONAL.
+    ///
+    /// If the list contains SKIP then while the interstitial is being
+    /// played, the client MUST NOT allow the user to seek forward from
+    /// the current playhead position or set the rate to greater than the
+    /// regular playback rate until playback reaches the end of the
+    /// interstitial.
+    ///
+    /// If the list contains JUMP then the client MUST NOT allow the user
+    /// to seek from a position in the primary asset earlier than the
+    /// START-DATE attribute to a position after it without first playing
+    /// the interstitial asset, even if the interstitial at START-DATE was
+    /// played through earlier.  If the user attempts to seek across more
+    /// than one interstitial, the client SHOULD choose at least one
+    /// interstitial to play before allowing the seek to complete.
+    case restrict = "X-RESTRICT"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// This attribute may have the value "POINT" or "RANGE".
+    /// The attribute indicates whether the interstitial should be presented as a
+    /// single point on the timeline or as a range.
+    /// If X-TIMELINE-OCCUPIES is missing it is considered to have a value of
+    /// "POINT" (which is typical for VOD presentations), although clients may infer
+    /// a value of "RANGE" if the interstitial has positive non-zero resumption offset.
+    /// This attribute is OPTIONAL
+    case timelineOccupies = "X-TIMELINE-OCCUPIES"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// This attribute may have the value "HIGHLIGHT" or "PRIMARY".
+    /// This attribute indicates whether the interstitial is intended to be presented as
+    /// distinct from the content ("HIGHLIGHT") or not differentiated ("PRIMARY").
+    /// If X-TIMELINE-STYLE is missing it is considered to have a value of "HIGHLIGHT"
+    /// This attribute is OPTIONAL
+    case timelineStyle = "X-TIMELINE-STYLE"
+    
+    /// Found in `.EXT_X_DATERANGE`.
+    ///
+    /// Provides a hint to the client to know how coordinated playback of
+    /// the same asset will behave across multiple players
+    /// A value of "NO" indicates all players will get the same interstitial content.
+    /// If this attribute is missing, it is considered to have a value of "YES".
+    /// This attribute is OPTIONAL
+    case contentMayVary = "X-CONTENT-MAY-VARY"
 
     /// Found in `.EXT_X_SKIP`.
     ///

--- a/mambaSharedFramework/PlaylistTagParser.swift
+++ b/mambaSharedFramework/PlaylistTagParser.swift
@@ -27,14 +27,14 @@ public struct PlaylistTagValueData {
     }
     /// The actual value
     let value: String
-    /// Inidcates if the value should be quote-escaped or not
+    /// Indicates if the value should be quote-escaped or not
     let quoteEscaped: Bool
 }
 
 public typealias PlaylistTagDictionary = OrderedDictionary<String, PlaylistTagValueData>
 
 /// Describes a object that parse an individual tag from a line in a HLS playlist
-public protocol PlaylistTagParser: class {
+public protocol PlaylistTagParser: AnyObject {
     
     /**
      Parses an playlist tag from a String. (i.e. if your tag is "#EXT-GENERICTAG:<Values>", you would pass "<Values>" as your string argument)

--- a/mambaSharedFramework/PlaylistValidationIssue.swift
+++ b/mambaSharedFramework/PlaylistValidationIssue.swift
@@ -98,5 +98,7 @@ public enum IssueDescription: String {
     case EXT_X_DATERANGETagPLANNED_DURATIONMustNotBeNegative = "PLANNED-DURATION MUST NOT be negative."
     case EXT_X_DATERANGEExistsWithNoEXT_X_PROGRAM_DATE_TIME = "If a Playlist contains an EXT-X-DATERANGE tag, it MUST also contain at least one EXT-X-PROGRAM-DATE-TIME tag."
     case EXT_X_DATERANGEAttributeMismatchForTagsWithSameID = "If a Playlist contains two EXT-X-DATERANGE tags with the same ID attribute value, then any AttributeName that appears in both tags MUST have the same AttributeValue."
+    case EXT_X_DATERANGEMissingAssetListOrAssetUriAttribute = "A Date Range tag specifying CLASS=com.apple.hls.interstitial must contain either an X-ASSET-LIST OR X-ASSET-URI attribute"
+    case EXT_X_DATERANGEContainsBothAssetListAndAssetUriAttribute = "A Date Range tag specifying CLASS=com.apple.hls.interstitial cannot contain both an X-ASSET-LIST AND X-ASSET-URI attribute"
 }
 

--- a/mambaSharedFramework/Utils/String Util/String+DateParsing.swift
+++ b/mambaSharedFramework/Utils/String Util/String+DateParsing.swift
@@ -21,7 +21,7 @@ import Foundation
 
 extension String {
     
-    private struct DateFormatter {
+    struct DateFormatter {
         static let iso8601MS: Foundation.DateFormatter = {
             let formatter = Foundation.DateFormatter()
             formatter.calendar = Calendar(identifier: Calendar.Identifier.iso8601)

--- a/mambaTests/Util Tests/InterstitialTagBuilderTests.swift
+++ b/mambaTests/Util Tests/InterstitialTagBuilderTests.swift
@@ -1,0 +1,113 @@
+//
+//  InterstitialTagBuilderTests.swift
+//  mambaTests
+//
+//  Created by Migneco, Ray on 10/23/24.
+//  Copyright © 2024 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import XCTest
+
+@testable import mamba
+
+
+final class InterstitialTagBuilderTests: XCTestCase {
+
+    func testTagBuilder() {
+
+        let startDate = Date()
+        let id: String = "12345"
+        let assetUri: String = "http://not.a.real.uri"
+        let assetListUri: String = "http://not.a.real.list"
+
+        let validator = EXT_X_DATERANGETagValidator()
+
+        // test URI
+        var tagBuilder = InterstitialTagBuilder(id: id,
+                                                startDate: startDate,
+                                                assetUri: assetUri)
+
+        var tag = decorateAndTest(tagBuilder)
+
+        XCTAssertEqual(tag.value(forValueIdentifier: PantosValue.startDate), String.DateFormatter.iso8601MS.string(from: startDate))
+        XCTAssertEqual(tag.value<String>(forValueIdentifier: PantosValue.id), id)
+        XCTAssertEqual(tag.value<String>(forValueIdentifier: PantosValue.assetUri), assetUri)
+        XCTAssertNil(tag.value<String>(forValueIdentifier: PantosValue.assetList))
+
+        XCTAssertNil(validator.validate(tag: tag))
+
+        // test asset list
+        tagBuilder = InterstitialTagBuilder(id: id,
+                                            startDate: startDate,
+                                            assetList: assetListUri)
+
+        tag = decorateAndTest(tagBuilder)
+
+        XCTAssertEqual(tag.value<String>(forValueIdentifier: PantosValue.assetList), assetListUri)
+        XCTAssertNil(tag.value<String>(forValueIdentifier: PantosValue.assetUri))
+
+        XCTAssertNil(validator.validate(tag: tag))
+    }
+
+    func decorateAndTest(_ tagBuilder: InterstitialTagBuilder) -> PlaylistTag {
+
+        let duration: Double = 10.0
+        let plannedDuration: Double = 10.0
+        let alignment = HLSInterstitialAlignment(values: [.in, .out])
+        let restrictions = HLSInterstitialSeekRestrictions(restrictions: [.skip, .jump])
+        let playoutLimit: Double = 30.0
+        let resumeOffset: Double = 5.0
+        let timelineStyle = HLSInterstitialTimelineStyle.highlight
+        let timelineOccupation = HLSInterstitialTimelineOccupation.point
+        let contentVariation = false
+        let clientAttributes: [String: LosslessStringConvertible] = ["X-COM-BEACON-URI": "http://not.a.real.beacon",
+                                                                     "X-COM-AD-PROVIDER-ID": 100]
+
+        let tag = tagBuilder
+            .withDuration(duration)
+            .withPlannedDuration(plannedDuration)
+            .withAlignment(alignment)
+            .withRestrictions(restrictions)
+            .withPlayoutLimit(playoutLimit)
+            .withResumeOffset(resumeOffset)
+            .withTimelineStyle(timelineStyle)
+            .withTimelineOccupation(timelineOccupation)
+            .withContentVariation(contentVariation)
+            .withClientAttributes(clientAttributes)
+            .buildTag()
+
+        XCTAssertEqual(tag.value<Double>(forValueIdentifier: PantosValue.duration), duration)
+        XCTAssertEqual(tag.value<Double>(forValueIdentifier: PantosValue.plannedDuration), plannedDuration)
+        XCTAssertEqual(tag.value<HLSInterstitialAlignment>(forValueIdentifier: PantosValue.snap), alignment)
+        XCTAssertEqual(tag.value<HLSInterstitialSeekRestrictions>(forValueIdentifier: PantosValue.restrict), restrictions)
+        XCTAssertEqual(tag.value<Double>(forValueIdentifier: PantosValue.playoutLimit), playoutLimit)
+        XCTAssertEqual(tag.value<Double>(forValueIdentifier: PantosValue.resumeOffset), resumeOffset)
+        XCTAssertEqual(tag.value<HLSInterstitialTimelineStyle>(forValueIdentifier: PantosValue.timelineStyle), timelineStyle)
+        XCTAssertEqual(tag.value<HLSInterstitialTimelineOccupation>(forValueIdentifier: PantosValue.timelineOccupies), timelineOccupation)
+        XCTAssertEqual(tag.value<Bool>(forValueIdentifier: PantosValue.contentMayVary), contentVariation)
+
+        // check client attributes
+        for (k, v) in clientAttributes {
+            guard let val = tag.value(forKey: k) else {
+                XCTFail("Expected to find value for key \(k)")
+                continue
+            }
+
+            XCTAssertEqual(val, v.description)
+        }
+
+        return tag
+    }
+
+}

--- a/mambaTests/Util Tests/Value Types/InterstitialValueTests.swift
+++ b/mambaTests/Util Tests/Value Types/InterstitialValueTests.swift
@@ -1,0 +1,59 @@
+//
+//  HLSInterstitialValueTests.swift
+//  mambaTests
+//
+//  Created by Migneco, Ray on 10/22/24.
+//  Copyright © 2024 Comcast Corporation.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License. All rights reserved.
+//
+
+import XCTest
+
+@testable import mamba
+
+final class HLSInterstitialValueTests: XCTestCase {
+
+    func testSnapAlignment() {
+        var vals = HLSInterstitialAlignment.Snap.allCases
+
+        XCTAssertEqual(HLSInterstitialAlignment(values: vals).values.count, 2)
+
+        // test de-duping
+        vals.append(HLSInterstitialAlignment.Snap.in)
+        XCTAssertEqual(HLSInterstitialAlignment(values: vals).values.count, 2)
+
+        // create from string
+        let inputStr = "IN,OUT"
+        XCTAssertEqual(HLSInterstitialAlignment(failableInitWithString: inputStr)?.values.count, 2)
+
+        let badInput = "up,down"
+        XCTAssertNil(HLSInterstitialAlignment(failableInitWithString: badInput))
+    }
+
+    func testRestrictions() {
+        var vals = HLSInterstitialSeekRestrictions.Restriction.allCases
+
+        XCTAssertEqual(HLSInterstitialSeekRestrictions(restrictions: vals).restrictions.count, 2)
+
+        // de-dupe
+        vals.append(HLSInterstitialSeekRestrictions.Restriction.jump)
+        XCTAssertEqual(HLSInterstitialSeekRestrictions(restrictions: vals).restrictions.count, 2)
+
+        let inputStr = "SKIP,JUMP"
+        XCTAssertEqual(HLSInterstitialSeekRestrictions(failableInitWithString: inputStr)?.restrictions.count, 2)
+
+        let badInput = "Forward,Back"
+        XCTAssertNil(HLSInterstitialSeekRestrictions(failableInitWithString: badInput))
+    }
+
+}


### PR DESCRIPTION
### Description

This PR adds support for Interstitial Tag Attributes as outlined in the [Appendix D of the HLS Spec](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#appendix-D)

_Note_ - this is a port of the work from https://github.com/Comcast/mamba/pull/144 but updated for Mamba 2.0 syntax

### Change Notes

* Adds `PantosValue` attributes to support interstitials
* Updates the `EXT_X_DATERANGETagValidator` to include additional values and include specific validation rules for HLS Interstitials
* Adds unit tests for the new validation rules
* Creates `HLSInterstitialValues` to represent the attribute options 
* Creates `InterstitialTagBuilder` which facilitates creating a `HLSTag` type configured specifically for interstitials
* Unit tests for `InterstitialTagBuilder`

### Pre-submission Checklist

- [x] I ran the unit tests locally before checking in.
- [x] I made sure there were no compiler warnings before checking in.
- [x] I have written useful documentation for all public code.
- [x] I have written unit tests for this new feature.